### PR TITLE
Fixes to issue #4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Unless specified otherwise, the entries in this changelog apply to file [`iso-19139-to-dcat-ap.xsl`](./iso-19139-to-dcat-ap.xsl).
 
+
+## 2020-11-05: Revised version (v2.1)
+
+* Revised mapping for conformance test results, to include also values specified via `gmx:Anchor`.
+* Revised mapping for originating controlled vocabularies, to include also values specified via `gmx:Anchor`.
+* Editorial revisions.
+
 ## 2020-06-22: New version (v2.0)
 
 This version includes revisions needed to ensure compliance with DCAT 2 and DCAT-AP 2.0, and reflecting the first working draft of GeoDCAT-AP 2.0.0:

--- a/iso-19139-to-dcat-ap.xsl
+++ b/iso-19139-to-dcat-ap.xsl
@@ -2658,7 +2658,7 @@
             <xsl:with-param name="term">dct:title</xsl:with-param>
           </xsl:call-template>
         </xsl:for-each>
-	<xsl:if test="$profile = $extended">
+        <xsl:if test="$profile = $extended">
           <xsl:apply-templates select="gmd:date/gmd:CI_Date"/>
         </xsl:if>
       </xsl:for-each>
@@ -2680,7 +2680,7 @@
     <xsl:param name="inScheme">
       <xsl:choose>
         <xsl:when test="$OriginatingControlledVocabularyURI != ''">
-          <skos:inScheme rdf:about="{$OriginatingControlledVocabularyURI}"/>
+          <skos:inScheme rdf:resource="{$OriginatingControlledVocabularyURI}"/>
         </xsl:when>
         <xsl:otherwise>
           <skos:inScheme>

--- a/iso-19139-to-dcat-ap.xsl
+++ b/iso-19139-to-dcat-ap.xsl
@@ -714,9 +714,13 @@
 
     <xsl:param name="Conformity">
       <xsl:for-each select="gmd:dataQualityInfo/*/gmd:report/*/gmd:result/*/gmd:specification/gmd:CI_Citation">
+        <xsl:variable name="specUri" select="normalize-space(gmd:title/gmx:Anchor/@xlink:href)"/>
         <xsl:variable name="specTitle">
           <xsl:for-each select="gmd:title">
+<!--
             <dct:title xml:lang="{$MetadataLanguage}"><xsl:value-of select="normalize-space(gco:CharacterString)"/></dct:title>
+-->
+	    <dct:title xml:lang="{$MetadataLanguage}"><xsl:value-of select="normalize-space(*[self::gco:CharacterString|self::gmx:Anchor])"/></dct:title>
             <xsl:call-template name="LocalisedString">
               <xsl:with-param name="term">dct:title</xsl:with-param>
             </xsl:call-template>
@@ -771,6 +775,16 @@
           <prov:qualifiedAssociation rdf:parseType="Resource">
             <prov:hadPlan rdf:parseType="Resource">
               <xsl:choose>
+                <xsl:when test="$specUri != ''">
+                  <prov:wasDerivedFrom rdf:resource="{$specUri}"/>
+<!--
+                  <prov:wasDerivedFrom>
+                    <rdf:Description rdf:about="{$specUri}">
+                      <xsl:copy-of select="$specinfo"/>
+                    </rdf:Description>
+                  </prov:wasDerivedFrom>
+-->
+                </xsl:when>
                 <xsl:when test="../@xlink:href and ../@xlink:href != ''">
                   <prov:wasDerivedFrom rdf:resource="{../@xlink:href}"/>
 <!--
@@ -1991,12 +2005,36 @@
     <xsl:param name="ResourceUri"/>
     <xsl:param name="MetadataLanguage"/>
     <xsl:param name="Conformity"/>
+
+    <xsl:variable name="specUri" select="normalize-space(gmd:title/gmx:Anchor/@xlink:href)"/>
+    <xsl:variable name="specTitle">
+      <xsl:for-each select="gmd:title">
+<!--
+        <dct:title xml:lang="{$MetadataLanguage}"><xsl:value-of select="normalize-space(gco:CharacterString)"/></dct:title>
+-->
+        <dct:title xml:lang="{$MetadataLanguage}"><xsl:value-of select="normalize-space(*[self::gco:CharacterString|self::gmx:Anchor])"/></dct:title>
+        <xsl:call-template name="LocalisedString">
+          <xsl:with-param name="term">dct:title</xsl:with-param>
+        </xsl:call-template>
+      </xsl:for-each>
+    </xsl:variable>
+    <xsl:variable name="specinfo">
+<!--        
+      <dct:title xml:lang="{$MetadataLanguage}">
+        <xsl:value-of select="gmd:title/gco:CharacterString"/>
+      </dct:title>
+-->        
+      <xsl:copy-of select="$specTitle"/>
+      <xsl:apply-templates select="gmd:date/gmd:CI_Date"/>
+    </xsl:variable>
+<!--
     <xsl:variable name="specinfo">
       <dct:title xml:lang="{$MetadataLanguage}">
         <xsl:value-of select="gmd:title/gco:CharacterString"/>
       </dct:title>
       <xsl:apply-templates select="gmd:date/gmd:CI_Date"/>
     </xsl:variable>
+-->
 <!--
     <xsl:variable name="degree">
       <xsl:choose>
@@ -2020,6 +2058,16 @@
 -->
     <xsl:if test="../../gmd:pass/gco:Boolean = 'true'">
       <xsl:choose>
+        <xsl:when test="$specUri != ''">
+          <dct:conformsTo rdf:resource="{$specUri}"/>
+<!--
+          <dct:conformsTo>
+            <rdf:Description rdf:about="{$specUri}">
+              <xsl:copy-of select="$specinfo"/>
+            </rdf:Description>
+          </dct:conformsTo>
+-->
+        </xsl:when>
         <xsl:when test="../@xlink:href and ../@xlink:href != ''">
           <dct:conformsTo rdf:resource="{../@xlink:href}"/>
 <!--

--- a/iso-19139-to-dcat-ap.xsl
+++ b/iso-19139-to-dcat-ap.xsl
@@ -814,16 +814,20 @@
           </prov:generated>
         </prov:Activity>
         </xsl:variable>
+<!--            
         <xsl:choose>
           <xsl:when test="$ResourceUri != ''">
             <xsl:copy-of select="$Activity"/>
           </xsl:when>
           <xsl:otherwise>
+-->            
             <prov:wasUsedBy>
               <xsl:copy-of select="$Activity"/>
             </prov:wasUsedBy>
+<!--            
           </xsl:otherwise>
         </xsl:choose>
+-->            
       </xsl:for-each>
     </xsl:param>
 
@@ -1343,9 +1347,11 @@
 <!--
     <xsl:if test="$profile = $extended and $ResourceUri != '' and $Conformity != ''">
 -->
+<!--
     <xsl:if test="$ResourceUri != '' and $Conformity != ''">
       <xsl:copy-of select="$Conformity"/>
     </xsl:if>
+-->
 
 
   </xsl:template>
@@ -2089,9 +2095,13 @@
 <!--
     <xsl:if test="$profile = $extended">
 -->
+<!--
       <xsl:if test="$Conformity != '' and $ResourceUri = ''">
+-->
         <xsl:copy-of select="$Conformity"/>
+<!--
       </xsl:if>
+-->
 <!--
       <xsl:choose>
         <xsl:when test="../@xlink:href and ../@xlink:href != ''">


### PR DESCRIPTION
* Revised mapping for conformity reference specifications, to include also values specified via `gmx:Anchor`.
* Revised mapping for originating controlled vocabularies, to include also values specified via `gmx:Anchor`.
* Editorial revisions.
* Updated `CHANGELOG.md` accordingly.