### PR TITLE
Revise mapping of spatial resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,18 @@
 
 Unless specified otherwise, the entries in this changelog apply to file [`iso-19139-to-dcat-ap.xsl`](./iso-19139-to-dcat-ap.xsl).
 
+## 2020-12-012: Revised version (v2.3)
+
+* Revised mapping of spatial resolution to align it with the current draft of GeoDCAT-AP 2.0.0 (see issue [#14](https://github.com/SEMICeu/iso-19139-to-dcat-ap/issues/14)). In particular, the mapping now supports the use of `dqv:hasQualityMeasurement` to complement `dcat:spatialResolutionInMeters` for the different types of spatial resolution (equivalent scale, distance, angular distance, and vertical distance).
+
 ## 2020-12-08: Revised version (v2.2)
 
-* Fixed typo in variable reference.
+* Fixed typo in variable reference (see issue [#11](https://github.com/SEMICeu/iso-19139-to-dcat-ap/issues/11)).
 
 ## 2020-11-05: Revised version (v2.1)
 
-* Revised mapping for conformance test results, to include also values specified via `gmx:Anchor`.
-* Revised mapping for originating controlled vocabularies, to include also values specified via `gmx:Anchor`.
+* Revised mapping for conformance test results, to include also values specified via `gmx:Anchor` (see issue [#4](https://github.com/SEMICeu/iso-19139-to-dcat-ap/issues/4)).
+* Revised mapping for originating controlled vocabularies, to include also values specified via `gmx:Anchor` (see issue [#4](https://github.com/SEMICeu/iso-19139-to-dcat-ap/issues/4)).
 * Editorial revisions.
 
 ## 2020-06-22: New version (v2.0)

--- a/iso-19139-to-dcat-ap.xsl
+++ b/iso-19139-to-dcat-ap.xsl
@@ -48,9 +48,11 @@
     xmlns:dcat   = "http://www.w3.org/ns/dcat#"
     xmlns:dct    = "http://purl.org/dc/terms/"
     xmlns:dctype = "http://purl.org/dc/dcmitype/"
+    xmlns:dqv    = "http://www.w3.org/ns/dqv#"
     xmlns:earl   = "http://www.w3.org/ns/earl#"
     xmlns:foaf   = "http://xmlns.com/foaf/0.1/"
     xmlns:gco    = "http://www.isotc211.org/2005/gco"
+    xmlns:geodcatap = "http://data.europa.eu/930/"
     xmlns:gmd    = "http://www.isotc211.org/2005/gmd"
     xmlns:gml    = "http://www.opengis.net/gml"
     xmlns:gmx    = "http://www.isotc211.org/2005/gmx"
@@ -64,6 +66,7 @@
     xmlns:rdf    = "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
     xmlns:rdfs   = "http://www.w3.org/2000/01/rdf-schema#"
     xmlns:schema = "http://schema.org/"
+    xmlns:sdmx-attribute = "http://purl.org/linked-data/sdmx/2009/attribute#"
     xmlns:skos   = "http://www.w3.org/2004/02/skos/core#"
     xmlns:srv    = "http://www.isotc211.org/2005/srv"
     xmlns:vcard  = "http://www.w3.org/2006/vcard/ns#"
@@ -2855,26 +2858,72 @@
           </xsl:otherwise>
         </xsl:choose>
       </xsl:variable>
+<!--
       <xsl:if test="$profile = $extended">
         <rdfs:comment xml:lang="en">Spatial resolution (distance): <xsl:value-of select="."/>&#160;<xsl:value-of select="$UoM"/></rdfs:comment>
       </xsl:if>
+-->
 <!-- Mapping moved to core profile for compliance with DCAT-AP 2 -->     
 <!-- Mapping added for compliance with DCAT-AP 2 -->     
       <xsl:choose>
-	<xsl:when test="($UoM = 'm' or starts-with($UoM, 'm ')) and number(.) = number(.)">
+        <xsl:when test="($UoM = 'm' or starts-with($UoM, 'm ')) and number(.) = number(.)">
           <dcat:spatialResolutionInMeters rdf:datatype="{$xsd}decimal"><xsl:value-of select="."/></dcat:spatialResolutionInMeters>
-	</xsl:when>
-	<xsl:when test="($UoM = 'km' or starts-with($UoM, 'km ')) and number(.) = number(.)">
+          <xsl:if test="$profile = 'extended'">
+            <dqv:hasQualityMeasurement>
+             <dqv:QualityMeasurement>
+                <dqv:isMeasurementOf rdf:resource="http://data.europa.eu/930/spatialResolutionAsDistance"/>
+                <dqv:value rdf:datatype="{$xsd}decimal"><xsl:value-of select="."/></dqv:value>
+                <sdmx-attribute:unitMeasure rdf:resource="http://www.wurvoc.org/vocabularies/om-1.8/metre"/>
+             </dqv:QualityMeasurement>
+            </dqv:hasQualityMeasurement>
+          </xsl:if>
+        </xsl:when>
+        <xsl:when test="($UoM = 'km' or starts-with($UoM, 'km ')) and number(.) = number(.)">
           <dcat:spatialResolutionInMeters rdf:datatype="{$xsd}decimal"><xsl:value-of select="(. * 1000)"/></dcat:spatialResolutionInMeters>
-	</xsl:when>
-	<xsl:when test="($UoM = 'ft' or starts-with($UoM, 'ft ')) and number(.) = number(.)">
+          <xsl:if test="$profile = 'extended'">
+            <dqv:hasQualityMeasurement>
+             <dqv:QualityMeasurement>
+                <dqv:isMeasurementOf rdf:resource="http://data.europa.eu/930/spatialResolutionAsDistance"/>
+                <dqv:value rdf:datatype="{$xsd}decimal"><xsl:value-of select="."/></dqv:value>
+                <sdmx-attribute:unitMeasure rdf:resource="http://www.wurvoc.org/vocabularies/om-1.8/kilometre"/>
+             </dqv:QualityMeasurement>
+            </dqv:hasQualityMeasurement>
+          </xsl:if>
+        </xsl:when>
+        <xsl:when test="($UoM = 'ft' or starts-with($UoM, 'ft ')) and number(.) = number(.)">
           <dcat:spatialResolutionInMeters rdf:datatype="{$xsd}decimal"><xsl:value-of select="(. * 0.3048)"/></dcat:spatialResolutionInMeters>
-	</xsl:when>
+          <xsl:if test="$profile = 'extended'">
+            <dqv:hasQualityMeasurement>
+             <dqv:QualityMeasurement>
+                <dqv:isMeasurementOf rdf:resource="http://data.europa.eu/930/spatialResolutionAsDistance"/>
+                <dqv:value rdf:datatype="{$xsd}decimal"><xsl:value-of select="."/></dqv:value>
+                <sdmx-attribute:unitMeasure rdf:resource="http://www.wurvoc.org/vocabularies/om-1.8/foot-international"/>
+             </dqv:QualityMeasurement>
+            </dqv:hasQualityMeasurement>
+          </xsl:if>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:if test="$profile = $extended">
+            <rdfs:comment xml:lang="en">Spatial resolution (distance): <xsl:value-of select="."/>&#160;<xsl:value-of select="$UoM"/></rdfs:comment>
+          </xsl:if>
+        </xsl:otherwise>
       </xsl:choose>
     </xsl:for-each>
     <xsl:if test="$profile = $extended">
       <xsl:for-each select="gmd:equivalentScale/gmd:MD_RepresentativeFraction/gmd:denominator">
-        <rdfs:comment xml:lang="en">Spatial resolution (equivalent scale): 1:<xsl:value-of select="gco:Integer"/></rdfs:comment>
+        <xsl:choose>
+          <xsl:when test="number(gco:Integer) = number(gco:Integer)">
+            <dqv:hasQualityMeasurement>
+              <dqv:QualityMeasurement>
+                <dqv:isMeasurementOf rdf:resource="http://data.europa.eu/930/spatialResolutionAsScale"/>
+                <dqv:value rdf:datatype="{$xsd}decimal"><xsl:value-of select="format-number((1 div gco:Integer), '0.########################')"/></dqv:value>
+              </dqv:QualityMeasurement>
+            </dqv:hasQualityMeasurement>
+          </xsl:when>
+          <xsl:otherwise>
+            <rdfs:comment xml:lang="en">Spatial resolution (equivalent scale): 1:<xsl:value-of select="gco:Integer"/></rdfs:comment>
+          </xsl:otherwise>
+        </xsl:choose>
       </xsl:for-each>
     </xsl:if>
   </xsl:template>

--- a/iso-19139-to-dcat-ap.xsl
+++ b/iso-19139-to-dcat-ap.xsl
@@ -2911,6 +2911,9 @@
     </xsl:for-each>
     <xsl:if test="$profile = $extended">
       <xsl:for-each select="gmd:equivalentScale/gmd:MD_RepresentativeFraction/gmd:denominator">
+<!--
+        <rdfs:comment xml:lang="en">Spatial resolution (equivalent scale): 1:<xsl:value-of select="gco:Integer"/></rdfs:comment>
+-->
         <xsl:choose>
           <xsl:when test="number(gco:Integer) = number(gco:Integer)">
             <dqv:hasQualityMeasurement>
@@ -2921,7 +2924,7 @@
             </dqv:hasQualityMeasurement>
           </xsl:when>
           <xsl:otherwise>
-            <rdfs:comment xml:lang="en">Spatial resolution (equivalent scale): 1:<xsl:value-of select="gco:Integer"/></rdfs:comment>
+            <rdfs:comment xml:lang="en">Spatial resolution (equivalent scale): <xsl:value-of select="gco:Integer"/></rdfs:comment>
           </xsl:otherwise>
         </xsl:choose>
       </xsl:for-each>


### PR DESCRIPTION
See https://github.com/SEMICeu/iso-19139-to-dcat-ap/issues/14

Revise the mapping to support the use of `dqv:hasQualityMeasurement` to complement `dcat:spatialResolutionInMeters` for the different types of spatial resolution (equivalent scale, distance, angular distance, and vertical distance).
