### PR TITLE
Revise mapping of responsible party roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 Unless specified otherwise, the entries in this changelog apply to file [`iso-19139-to-dcat-ap.xsl`](./iso-19139-to-dcat-ap.xsl).
 
-## 2020-12-012: Revised version (v2.3)
+## 2020-12-17: Revised version (v2.4)
+
+* Revised mappings of responsible party roles to align them with the current draft of GeoDCAT-AP 2.0.0 (see issue [#32](https://github.com/SEMICeu/iso-19139-to-dcat-ap/issues/32)). In particular, the mapping now includes the use of the relevant properties defined in GeoDCAT-AP 2 - namely, `geodcatap:custodian`, `geodcatap:distributor`, `geodcatap:originator`, `geodcatap:principalInvestigator`, `geodcatap:processor`, `geodcatap:resourceProvider`, `geodcatap:user`.
+
+## 2020-12-12: Revised version (v2.3)
 
 * Revised mapping of spatial resolution to align it with the current draft of GeoDCAT-AP 2.0.0 (see issue [#14](https://github.com/SEMICeu/iso-19139-to-dcat-ap/issues/14)). In particular, the mapping now supports the use of `dqv:hasQualityMeasurement` to complement `dcat:spatialResolutionInMeters` for the different types of spatial resolution (equivalent scale, distance, angular distance, and vertical distance).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Unless specified otherwise, the entries in this changelog apply to file [`iso-19
 
 ## 2020-12-17: Revised version (v2.4)
 
-* Revised mappings of responsible party roles to align them with the current draft of GeoDCAT-AP 2.0.0 (see issue [#32](https://github.com/SEMICeu/iso-19139-to-dcat-ap/issues/32)). In particular, the mapping now includes the use of the relevant properties defined in GeoDCAT-AP 2 - namely, `geodcatap:custodian`, `geodcatap:distributor`, `geodcatap:originator`, `geodcatap:principalInvestigator`, `geodcatap:processor`, `geodcatap:resourceProvider`, `geodcatap:user`.
+* Revised mappings of responsible party roles to align them with the current draft of GeoDCAT-AP 2.0.0 (see issue [#16](https://github.com/SEMICeu/iso-19139-to-dcat-ap/issues/16)). In particular, the mapping now includes the use of the relevant properties defined in GeoDCAT-AP 2 - namely, `geodcatap:custodian`, `geodcatap:distributor`, `geodcatap:originator`, `geodcatap:principalInvestigator`, `geodcatap:processor`, `geodcatap:resourceProvider`, `geodcatap:user`.
 
 ## 2020-12-12: Revised version (v2.3)
 

--- a/iso-19139-to-dcat-ap.xsl
+++ b/iso-19139-to-dcat-ap.xsl
@@ -857,12 +857,12 @@
       </xsl:if>
 <!-- Metadata date -->
       <xsl:if test="$MetadataDate != ''">
-         <xsl:variable name="data-type">
-            <xsl:call-template name="DateDataType">
-              <xsl:with-param name="date" select="$MetadataDate"/>
-            </xsl:call-template>
-	</xsl:variable>
-	<dct:modified rdf:datatype="{$xsd}{$data-type}">
+        <xsl:variable name="data-type">
+          <xsl:call-template name="DateDataType">
+            <xsl:with-param name="date" select="$MetadataDate"/>
+          </xsl:call-template>
+        </xsl:variable>
+        <dct:modified rdf:datatype="{$xsd}{$data-type}">
           <xsl:value-of select="$MetadataDate"/>
         </dct:modified>
       </xsl:if>
@@ -1147,34 +1147,34 @@
         <xsl:apply-templates select="gmd:identificationInfo/*/gmd:spatialRepresentationType/gmd:MD_SpatialRepresentationTypeCode"/>
       </xsl:variable>
 
-          <xsl:for-each select="gmd:distributionInfo/gmd:MD_Distribution">
+      <xsl:for-each select="gmd:distributionInfo/gmd:MD_Distribution">
 <!-- Encoding -->
-            <xsl:variable name="Encoding">
-               <xsl:apply-templates select="gmd:distributionFormat/gmd:MD_Format/gmd:name/*"/>
-            </xsl:variable>
+        <xsl:variable name="Encoding">
+          <xsl:apply-templates select="gmd:distributionFormat/gmd:MD_Format/gmd:name/*"/>
+        </xsl:variable>
 <!-- Resource locators (access / download URLs) -->
-            <xsl:for-each select="gmd:transferOptions/*/gmd:onLine/*">
-              <xsl:variable name="url" select="gmd:linkage/gmd:URL"/>
-              <xsl:variable name="protocol" select="gmd:protocol/*"/>
-	      <xsl:variable name="protocol-url" select="gmd:protocol/gmx:Anchor/@xlink:href"/>
-              <xsl:variable name="function" select="gmd:function/gmd:CI_OnLineFunctionCode/@codeListValue"/>
-              <xsl:variable name="Title">
-                <xsl:for-each select="gmd:name">
-                  <dct:title xml:lang="{$MetadataLanguage}"><xsl:value-of select="normalize-space(gco:CharacterString)"/></dct:title>
-                  <xsl:call-template name="LocalisedString">
-                    <xsl:with-param name="term">dct:title</xsl:with-param>
-                  </xsl:call-template>
-                </xsl:for-each>
-              </xsl:variable>
-              <xsl:variable name="Description">
-                <xsl:for-each select="gmd:description">
-                  <dct:description xml:lang="{$MetadataLanguage}"><xsl:value-of select="normalize-space(gco:CharacterString)"/></dct:description>
-                  <xsl:call-template name="LocalisedString">
-                    <xsl:with-param name="term">dct:description</xsl:with-param>
-                  </xsl:call-template>
-                </xsl:for-each>
-              </xsl:variable>
-              <xsl:variable name="TitleAndDescription">
+        <xsl:for-each select="gmd:transferOptions/*/gmd:onLine/*">
+          <xsl:variable name="url" select="gmd:linkage/gmd:URL"/>
+          <xsl:variable name="protocol" select="gmd:protocol/*"/>
+          <xsl:variable name="protocol-url" select="gmd:protocol/gmx:Anchor/@xlink:href"/>
+          <xsl:variable name="function" select="gmd:function/gmd:CI_OnLineFunctionCode/@codeListValue"/>
+          <xsl:variable name="Title">
+            <xsl:for-each select="gmd:name">
+              <dct:title xml:lang="{$MetadataLanguage}"><xsl:value-of select="normalize-space(gco:CharacterString)"/></dct:title>
+              <xsl:call-template name="LocalisedString">
+                <xsl:with-param name="term">dct:title</xsl:with-param>
+              </xsl:call-template>
+            </xsl:for-each>
+          </xsl:variable>
+          <xsl:variable name="Description">
+            <xsl:for-each select="gmd:description">
+              <dct:description xml:lang="{$MetadataLanguage}"><xsl:value-of select="normalize-space(gco:CharacterString)"/></dct:description>
+              <xsl:call-template name="LocalisedString">
+                <xsl:with-param name="term">dct:description</xsl:with-param>
+              </xsl:call-template>
+            </xsl:for-each>
+          </xsl:variable>
+          <xsl:variable name="TitleAndDescription">
 <!--              
                 <xsl:for-each select="gmd:name/gco:CharacterString">
                   <dct:title xml:lang="{$MetadataLanguage}"><xsl:value-of select="."/></dct:title>
@@ -1183,13 +1183,13 @@
                   <dct:description xml:lang="{$MetadataLanguage}"><xsl:value-of select="."/></dct:description>
                 </xsl:for-each>
 -->
-                <xsl:copy-of select="$Title"/>
-                <xsl:copy-of select="$Description"/>
-              </xsl:variable>
+            <xsl:copy-of select="$Title"/>
+            <xsl:copy-of select="$Description"/>
+          </xsl:variable>
 
       <xsl:choose>
 <!-- Mapping added to the core profile for compliance with DCAT-AP 2 -->	      
-	<xsl:when test="$ResourceType = 'service'">
+        <xsl:when test="$ResourceType = 'service'">
           <xsl:call-template name="service-endpoint">
             <xsl:with-param name="function" select="$function"/>
             <xsl:with-param name="protocol" select="$protocol"/>
@@ -1724,24 +1724,25 @@
       </xsl:choose>
     </xsl:param>
     <xsl:choose>
-<!--
-      <xsl:when test="$role = 'resourceProvider'">
-        <schema:provider>
+      <xsl:when test="$role = 'resourceProvider' and $profile = $extended">
+        <geodcatap:resourceProvider>
           <xsl:copy-of select="$ROInfo"/>
-        </schema:provider>
+        </geodcatap:resourceProvider>
       </xsl:when>
--->
-<!--
-      <xsl:when test="$role = 'custodian'">
-        <rdarole:custodian>
+      <xsl:when test="$role = 'custodian' and $profile = $extended">
+        <geodcatap:custodian>
           <xsl:copy-of select="$ROInfo"/>
-        </rdarole:custodian>
+        </geodcatap:custodian>
       </xsl:when>
--->
       <xsl:when test="$role = 'owner' and $profile = $extended">
         <dct:rightsHolder>
           <xsl:copy-of select="$ROInfo"/>
         </dct:rightsHolder>
+      </xsl:when>
+      <xsl:when test="$role = 'user' and $profile = $extended">
+        <geodcatap:user>
+          <xsl:copy-of select="$ROInfo"/>
+        </geodcatap:user>
       </xsl:when>
 <!--
       <xsl:when test="$role = 'user'">
@@ -1754,22 +1755,18 @@
         </prov:wasUsedBy>
       </xsl:when>
 -->
-<!--
-      <xsl:when test="$role = 'distributor'">
-        <rdarole:distributor>
+      <xsl:when test="$role = 'distributor' and $profile = $extended">
+        <geodcatap:distributor>
           <xsl:copy-of select="$ROInfo"/>
-        </rdarole:distributor>
+        </geodcatap:distributor>
       </xsl:when>
--->
-<!--
       <xsl:when test="$role = 'originator' and $profile = $extended">
-        <dct:creator>
+        <geodcatap:originator>
           <xsl:copy-of select="$ROInfo"/>
-        </dct:creator>
+        </geodcatap:originator>
       </xsl:when>
--->
 <!-- Mapping applied also to services for compliance with DCAT-AP 2 -->
-      <xsl:when test="$role = 'pointOfContact'">
+      <xsl:when test="$role = 'pointOfContact' and ($ResourceType != 'service' or $profile = $extended)">
         <dcat:contactPoint>
           <xsl:copy-of select="$ResponsibleParty"/>
         </dcat:contactPoint>
@@ -1781,13 +1778,16 @@
         </dcat:contactPoint>
       </xsl:when>
 -->
-<!--
-      <xsl:when test="$role = 'principalInvestigator'">
-        <dct:contributor>
+      <xsl:when test="$role = 'principalInvestigator' and $profile = $extended">
+        <geodcatap:principalInvestigator>
           <xsl:copy-of select="$ROInfo"/>
-        </dct:contributor>
+        </geodcatap:principalInvestigator>
       </xsl:when>
--->
+      <xsl:when test="$role = 'processor' and $profile = $extended">
+        <geodcatap:processor>
+          <xsl:copy-of select="$ROInfo"/>
+        </geodcatap:processor>
+      </xsl:when>
 <!--
       <xsl:when test="$role = 'processor'">
         <prov:entityOfInfluence>
@@ -1803,13 +1803,13 @@
         </prov:entityOfInfluence>
       </xsl:when>
 -->
-      <xsl:when test="$role = 'publisher'">
+      <xsl:when test="$role = 'publisher' and ($ResourceType != 'service' or $profile = $extended)">
         <dct:publisher>
           <xsl:copy-of select="$ROInfo"/>
         </dct:publisher>
       </xsl:when>
 <!-- Mapping moved to core profile for compliance with DCAT-AP 2 -->
-      <xsl:when test="$role = 'author'">
+      <xsl:when test="$role = 'author' and ($ResourceType != 'service' or $profile = $extended)">
         <dct:creator>
           <xsl:copy-of select="$ROInfo"/>
         </dct:creator>
@@ -1823,9 +1823,7 @@
 -->
     </xsl:choose>
 <!-- Mapping moved to core profile for compliance with DCAT-AP 2 -->
-<!--
-    <xsl:if test="$profile = $extended">
--->
+    <xsl:if test="($ResourceType != 'service' and $role != 'pointOfContact' and $role != 'publisher' and $role != 'author') or $profile = $extended">
       <prov:qualifiedAttribution>
         <prov:Attribution>
           <prov:agent>
@@ -1837,14 +1835,12 @@
 <!-- DEPRECATED: Mapping kept for backward compatibility with GeoDCAT-AP v1.* -->      
           <xsl:if test="$profile = $extended">
             <dct:type rdf:resource="{$ResponsiblePartyRole}"/>
-	  </xsl:if>
+          </xsl:if>
 <!-- Mapping added for compliance with DCAT-AP 2 -->      
           <dcat:hadRole rdf:resource="{$ResponsiblePartyRole}"/>
         </prov:Attribution>
       </prov:qualifiedAttribution>
-<!--          
     </xsl:if>
--->            
   </xsl:template>
 
 <!-- Metadata point of contact -->


### PR DESCRIPTION
See https://github.com/SEMICeu/iso-19139-to-dcat-ap/issues/16

Revise mappings to include the use of the relevant properties defined in GeoDCAT-AP 2 - namely, `geodcatap:custodian`, `geodcatap:distributor`, `geodcatap:originator`, `geodcatap:principalInvestigator`, `geodcatap:processor`, `geodcatap:resourceProvider`, `geodcatap:user`.