### PR TITLE
Avoid failure when multiple resource identifier are set

### DIFF
--- a/iso-19139-to-dcat-ap.xsl
+++ b/iso-19139-to-dcat-ap.xsl
@@ -85,7 +85,7 @@
     xmlns:xsi    = "http://www.w3.org/2001/XMLSchema-instance"
     xmlns:xsl    = "http://www.w3.org/1999/XSL/Transform"
     exclude-result-prefixes="earl gco gmd gml gmx i i-gp srv xlink xsi xsl wdrs"
-    version="1.0">
+    version="2.0">
 
   <xsl:output method="xml"
               indent="yes"
@@ -437,13 +437,41 @@
 
   The default rule implies that HTTP URIs are specified for the metadata file identifier
   (metadata URI) and the resource identifier (resource URI).
-
+    
+  Resource URI can be an http or https URI based on:
+  * codeSpace + code value
+  * code value
+  The first URI found is used.
 -->
 
   <xsl:param name="ResourceUri">
-    <xsl:variable name="rURI" select="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:identifier/*/gmd:code/gco:CharacterString"/>
-    <xsl:if test="$rURI != '' and ( starts-with($rURI, 'http://') or starts-with($rURI, 'https://') )">
-      <xsl:value-of select="$rURI"/>
+    <xsl:variable name="identifiers"
+                    select="gmd:identificationInfo/*/gmd:citation/*/
+                              gmd:identifier/*"/>
+
+      <xsl:variable name="uriIdentifiers"
+                    as="node()*">
+        <xsl:for-each select="$identifiers">
+          <xsl:variable name="rURI"
+                        select="if (gmd:codeSpace)
+                                then concat(
+                                      gmd:codeSpace/(gco:CharacterString
+                                                     |gmx:Anchor/@xlink:href),
+                                      gmd:code/(gco:CharacterString
+                                                |gmx:Anchor/@xlink:href))
+                                else gmd:code/(gco:CharacterString/text()
+                                               |gmx:Anchor/@xlink:href)"/>
+          <xsl:if test="matches($rURI, '^https?://')">
+            <uri><xsl:value-of select="$rURI"/></uri>
+          </xsl:if>
+        </xsl:for-each>
+      </xsl:variable>
+
+      <xsl:if test="count($uriIdentifiers) > 0">
+        <xsl:value-of select="$uriIdentifiers[1]"/>
+        <xsl:if test="count($uriIdentifiers) > 1">
+          <xsl:message>ResourceUri is <xsl:value-of select="$uriIdentifiers[1]"/>. Ignored: <xsl:value-of select="string-join($uriIdentifiers[position() > 1], ',')"/>. </xsl:message>
+        </xsl:if>
     </xsl:if>
   </xsl:param>
 


### PR DESCRIPTION
* Add support for multiple resource identifiers
* Concatenate codespace with code if codespace is set
* Take first URI matching http pattern (and log ignored ones).
* Update to XSLT version 2 (required for the `matches` function)

eg. https://metawal.wallonie.be/geonetwork/srv/eng/catalog.search#/metadata/44a75314-f27e-4952-b96a-50f1408232b3


```xml
          <gmd:identifier>
            <gmd:RS_Identifier>
              <gmd:code>
                <gco:CharacterString>44a75314-f27e-4952-b96a-50f1408232b3</gco:CharacterString>
              </gmd:code>
              <gmd:codeSpace>
                <gco:CharacterString>http://geodata.wallonie.be/id/</gco:CharacterString>
              </gmd:codeSpace>
            </gmd:RS_Identifier>
          </gmd:identifier>
          <gmd:identifier>
            <gmd:MD_Identifier>
              <gmd:code>
                <gco:CharacterString>LU_PlannedLandUse_PDS</gco:CharacterString>
              </gmd:code>
            </gmd:MD_Identifier>
```