### PR TITLE
Fix handling of dates in datetime format

### DIFF
--- a/iso-19139-to-dcat-ap.xsl
+++ b/iso-19139-to-dcat-ap.xsl
@@ -2666,7 +2666,14 @@
 
   <xsl:template name="Dates" match="gmd:date/gmd:CI_Date">
     <xsl:param name="date">
-      <xsl:value-of select="normalize-space(gmd:date/gco:Date)"/>
+      <xsl:choose>
+        <xsl:when test="gmd:date/gco:Date">
+          <xsl:value-of select="normalize-space(gmd:date/gco:Date)"/>
+        </xsl:when>
+        <xsl:when test="gmd:date/gco:DateTime">
+          <xsl:value-of select="normalize-space(gmd:date/gco:DateTime)"/>
+        </xsl:when>
+      </xsl:choose>
     </xsl:param>
     <xsl:param name="type">
       <xsl:value-of select="gmd:dateType/gmd:CI_DateTypeCode/@codeListValue"/>


### PR DESCRIPTION
Fix #50

Fix uses [code already present in another part of the XSL](https://github.com/SEMICeu/iso-19139-to-dcat-ap/blob/dev/iso-19139-to-dcat-ap.xsl#L761).

**Fixed output** (example in ticket)
```
  <rdf:Description rdf:about="https://catalogue.datara.gouv.fr/geonetwork/srv/8958e8ed-69f5-4784-830c-7171766cef49">
    ...
      <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-06-22T18:00:00</dct:issued>
      <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-07-26T23:46:22</dct:modified>
      <dct:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-06-22T18:00:00</dct:created>
```