### PR TITLE
Added Python example script and updated documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+.vscode
+env
+venv
+.env
+
+# Examples
+output
+documentation/examples/*/iso19139-to-geodcatap.xsl
+
+# Configuration files
+documentation/examples/*/config.yaml

--- a/documentation/HowTo.md
+++ b/documentation/HowTo.md
@@ -112,30 +112,9 @@ NOTE: After update to XSLT 2.0 with GeoDCAT-AP 3.0.0, the examples may be outdat
 ````
 
 ### Python
-
-````python
-import lxml.etree as ET
-from urllib2 import urlopen
-
-# The URL of the XML document to be transformed. Here it corresponds to a "GetRecords" output of a fictitious CSW, with the "maxRecords" parameter set to 10.
-xmlURL = "http://some.site/csw?request=GetRecords&service=CSW&version=2.0.2&namespace=xmlns%28csw=http://www.opengis.net/cat/csw%29&resultType=results&outputSchema=http://www.isotc211.org/2005/gmd&outputFormat=application/xml&typeNames=csw:Record&elementSetName=full&constraintLanguage=CQL_TEXT&constraint_language_version=1.1.0&maxRecords=10"
-
-# The URL pointing to the latest version of the XSLT.
-xslURL = "https://raw.githubusercontent.com/SEMICeu/iso-19139-to-dcat-ap/master/iso-19139-to-dcat-ap.xsl"
-  
-xml = ET.parse(urlopen(xmlURL))
-xsl = ET.parse(urlopen(xslURL))
-
-transform = ET.XSLT(xsl)
-
-print(ET.tostring(transform(xml), pretty_print=True))
-````
-
-### Python: command line tool
-
-A Python script that can be used as a command line tool has been contributed by [@arbakker](https://github.com/arbakker):
-
-https://gist.github.com/arbakker/42f73421654b4d5f29211ead2ae0ab25/
+Examples: 
+* [Python](./examples/py/iso-19139-to-dcat-ap.py): A Python script that demonstrates how to use the `iso-19139-to-dcat-ap.xsl` XSLT transformation to convert ISO 19139 metadata records to DCAT-AP format.
+* [Python: command line tool](https://gist.github.com/arbakker/42f73421654b4d5f29211ead2ae0ab25/) [**`obsolete`**]: A Python script that can be used as a command line tool has been contributed by [@arbakker](https://github.com/arbakker):
 
 ### Java
 

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -6,4 +6,5 @@ More precisely:
 * [`HTTP-URIs.md`](./HTTP-URIs.md): Provides the list of transformation rules currently implemented for identifying URIs embedded in ISO 19139 metadata records.
 * [`Mappings.md`](./Mappings.md): Provides a summary of the mappings from ISO 19139 to (Geo)DCAT-AP.
 * [`README.md`](./README.md): This document.
-
+* [`examples`](./examples/): Contains example scripts and configurations.
+    * [Python](./examples/py): A Python script that demonstrates how to use the [`iso-19139-to-dcat-ap.xsl`](./examples/py/iso-19139-to-dcat-ap.py) XSLT transformation to convert ISO 19139 metadata records to DCAT-AP format.

--- a/documentation/examples/py/README.md
+++ b/documentation/examples/py/README.md
@@ -1,0 +1,87 @@
+## Running iso-19139-to-dcat-ap.py
+
+## Prerequisites
+
+Make sure you have [Python 3.6 ](https://www.python.org/downloads/)or higher installed on your system.
+
+### Creating a virtual environment
+
+To create a virtual environment, follow these steps:
+
+1. Open a terminal and navigate to the directory containing the `iso-19139-to-dcat-ap.py` script.
+
+2. Create a virtual environment by issuing the following command:
+
+    - On Windows:
+
+        ```sh
+        python -m venv env
+        ```
+
+    - On MacOS and Linux:
+
+        ```sh
+        python3 -m venv env
+        ```
+
+3. Enable the virtual environment:
+
+    - On Windows:
+
+        ```sh
+        .\env\Scripts\activate
+        ```
+
+    - On MacOS and Linux:
+
+        ```sh
+        source env/bin/activate
+        ```
+
+### Installing the prerequisites
+
+With the virtual environment activated, install the necessary prerequisites by running the following command:
+
+- On Windows, MacOS and Linux:
+
+    ```sh
+    pip install -r requirements.txt
+    ```
+
+## Configuration
+
+### Generating the `config.yaml`
+
+To configure the script, you need to create a `config.yaml` file based on the provided `config.yaml.example`. You can do this by copying the example file:
+
+- On Windows:
+
+    ```sh
+    copy config.yaml.example config.yaml
+    ```
+
+- On MacOS and Linux:
+
+    ```sh
+    cp config.yaml.example config.yaml
+    ```
+
+### Options in `config.yaml`
+
+- `xml_url`: The URL to the CSW endpoint. Example:
+  ```yaml
+  xml_url: http://some.site/csw?request=GetRecords&service=CSW&version=2.0.2&namespace=xmlns%28csw=http://www.opengis.net/cat/csw%29&resultType=results&outputSchema=http://www.isotc211.org/2005/gmd&outputFormat=application/xml&typeNames=csw:Record&elementSetName=full&constraintLanguage=CQL_TEXT&constraint_language_version=1.1.0&maxRecords=10
+  ```
+
+- `xsl_url`: The URL to the XSLT transformation or the local XSLT file path. Example:
+  ```yaml
+  xsl_url: https://raw.githubusercontent.com/mjanez/iso-19139-to-dcat-ap/refs/heads/develop/iso-19139-to-dcat-ap.xsl
+  ```
+
+### Running the script
+
+Once you have configured the `config.yaml` file, you can run the script as follows:
+
+```sh
+python iso-19139-to-dcat-ap.py
+```

--- a/documentation/examples/py/config.yaml.example
+++ b/documentation/examples/py/config.yaml.example
@@ -1,0 +1,5 @@
+# XML URL to the CSW endpoint
+xml_url: http://some.site/csw?request=GetRecords&service=CSW&version=2.0.2&namespace=xmlns%28csw=http://www.opengis.net/cat/csw%29&resultType=results&outputSchema=http://www.isotc211.org/2005/gmd&outputFormat=application/xml&typeNames=csw:Record&elementSetName=full&constraintLanguage=CQL_TEXT&constraint_language_version=1.1.0&maxRecords=10
+
+# XSL URL to the XSLT transformation or the XLST local file, example: /tmp/xslt/my-mappings/iso-19139-to-dcat-ap.xsl
+xsl_url: https://raw.githubusercontent.com/mjanez/iso-19139-to-dcat-ap/refs/heads/develop/iso-19139-to-dcat-ap.xsl

--- a/documentation/examples/py/iso-19139-to-dcat-ap.py
+++ b/documentation/examples/py/iso-19139-to-dcat-ap.py
@@ -1,0 +1,113 @@
+import os
+import tempfile
+import logging
+import yaml
+from saxonche import PySaxonProcessor
+from rdflib import Graph
+from urllib.request import urlopen, urlretrieve
+import ssl
+
+# Load configuration from YAML file
+config_path = os.path.join(os.path.dirname(__file__), 'config.yaml')
+with open(config_path, 'r') as config_file:
+    config = yaml.safe_load(config_file)
+
+# Extract URLs from configuration
+XML_URL = config['xml_url']
+XSL_URL = config['xsl_url']
+LOCAL_XSL_PATH = os.path.join(os.path.dirname(__file__), "iso19139-to-geodcatap.xsl")
+
+# Logging configuration
+logging.basicConfig(level=logging.DEBUG)
+log = logging.getLogger(__name__)
+
+class XSLTTransformer:
+    """Class to handle XSLT transformations using SaxonC.
+
+    Attributes:
+        xslt_path (str): Path to the XSLT file.
+        processor (PySaxonProcessor): SaxonC processor instance.
+        xslt_processor (Xslt30Processor): SaxonC XSLT 3.0 processor instance.
+    """
+
+    def __init__(self, xslt_file):
+        """Initializes the XSLTTransformer with the given XSLT file.
+
+        Args:
+            xslt_file (str): Path or URL to the XSLT file.
+
+        Raises:
+            FileNotFoundError: If the XSLT file does not exist.
+        """
+        log.debug("Initializing XSLTTransformer with xslt_file: %s", xslt_file)
+
+        if xslt_file.startswith('http://') or xslt_file.startswith('https://'):
+            self.xslt_path = LOCAL_XSL_PATH
+            if not os.path.isfile(self.xslt_path):
+                log.debug("Downloading XSLT file from URL: %s", xslt_file)
+                urlretrieve(xslt_file, self.xslt_path)
+        else:
+            if not os.path.isfile(xslt_file):
+                raise FileNotFoundError(f"The file {xslt_file} does not exist.")
+            self.xslt_path = os.path.abspath(xslt_file)
+
+        self.processor = PySaxonProcessor(license=False)
+        self.xslt_processor = self.processor.new_xslt30_processor()
+
+        log.debug("XSLTTransformer initialized successfully.")
+
+    def transform(self, xml_data):
+        """Transforms the given XML data using the XSLT file.
+
+        Args:
+            xml_data (str or bytes): The XML data to transform.
+
+        Returns:
+            str: The transformed RDF data.
+
+        Raises:
+            RuntimeError: If there is an error in the XSLT transformation.
+            Exception: If there is a general error during transformation.
+        """
+        log.debug("Starting XML transformation.")
+        try:
+            if isinstance(xml_data, bytes):
+                xml_data = xml_data.decode('utf-8')
+
+            with tempfile.NamedTemporaryFile(delete=False, suffix=".xml", mode='w', encoding='utf-8') as temp_file:
+                temp_file.write(xml_data)
+                temp_file_path = temp_file.name
+
+            result = self.xslt_processor.transform_to_string(
+                stylesheet_file=self.xslt_path,
+                source_file=temp_file_path
+            )
+            if self.xslt_processor.exception_occurred:
+                for error in self.xslt_processor.get_error_message():
+                    log.error("Error in XSLT transformation: %s", error)
+                raise RuntimeError("Error in XSLT transformation")
+
+            # Save the result to a file in the output directory
+            output_dir = os.path.join(os.path.dirname(__file__), 'output')
+            os.makedirs(output_dir, exist_ok=True)
+            output_file_path = os.path.join(output_dir, 'transformed_output.rdf')
+            with open(output_file_path, 'w', encoding='utf-8') as output_file:
+                output_file.write(result)
+
+            log.debug("XML transformation completed successfully. Result saved in %s", output_file_path)
+            return result
+        except Exception as e:
+            log.error("Failed to transform XML content: %s", e)
+            raise
+
+# Create an unverified SSL context
+context = ssl._create_unverified_context()
+
+# Download and read the XML content
+xml_content = urlopen(XML_URL, context=context).read()
+
+# Initialize the XSLT transformer
+transformer = XSLTTransformer(xslt_file=XSL_URL)
+
+# Transform the XML content
+rdf_result = transformer.transform(xml_content)

--- a/documentation/examples/py/requirements.txt
+++ b/documentation/examples/py/requirements.txt
@@ -1,0 +1,4 @@
+# CSW Harvester
+saxonche==12.5.0
+rdflib>=6.1.1,<7.1.0
+PyYAML==6.0.2


### PR DESCRIPTION
- Included a Python script (iso-19139-to-dcat-ap.py) that demonstrates how to use the iso-19139-to-dcat-ap.xsl XSLT transformation to convert ISO 19139 metadata records to DCAT-AP format.
- Updated README.md to include instructions on generating the config.yaml file from config.yaml.example and configuring the necessary options. -Usage of saxonche for XSLT transformations and other libraries used in the script.