### PR TITLE
Add missing frequencies

### DIFF
--- a/iso-19139-to-dcat-ap.xsl
+++ b/iso-19139-to-dcat-ap.xsl
@@ -3843,6 +3843,10 @@
 -->
             <xsl:value-of select="concat($opfq,'BIWEEKLY')"/>
           </xsl:when>
+          <xsl:when test="@codeListValue = 'semimonthly'">
+<!--  A mapping is missing in Dublin Core -->
+            <xsl:value-of select="concat($opfq,'MONTHLY_2')"/>
+          </xsl:when>
           <xsl:when test="@codeListValue = 'monthly'">
 <!--  DC Freq voc
             <xsl:value-of select="concat($cldFrequency,'monthly')"/>
@@ -3866,6 +3870,14 @@
             <xsl:value-of select="concat($cldFrequency,'annual')"/>
 -->
             <xsl:value-of select="concat($opfq,'ANNUAL')"/>
+          </xsl:when>
+          <xsl:when test="@codeListValue = 'biennially'">
+<!--  A mapping is missing in Dublin Core -->
+            <xsl:value-of select="concat($opfq,'BIENNIAL')"/>
+          </xsl:when>
+          <xsl:when test="@codeListValue = 'periodic'">
+<!--  A mapping is missing in Dublin Core -->
+            <xsl:value-of select="concat($opfq,'OTHER')"/>
           </xsl:when>
           <xsl:when test="@codeListValue = 'asNeeded'">
 <!--  A mapping is missing in Dublin Core -->


### PR DESCRIPTION
Fix #79.

Maps remaining [ISO-19115 MD_MaintenanceFrequencyCode](https://schemas.isotc211.org/19115/resources/Codelist/cat/codelists.xml#MD_MaintenanceFrequencyCode) to the most appropriate [EU vocabulary](https://op.europa.eu/en/web/eu-vocabularies/concept-scheme/-/resource?uri=http://publications.europa.eu/resource/authority/frequency) equivalent.