### PR TITLE
GH-90: configurable locale prefix, default language + test

### DIFF
--- a/iso-19139-to-dcat-ap.xsl
+++ b/iso-19139-to-dcat-ap.xsl
@@ -192,12 +192,26 @@
     </xsl:choose>
   </xsl:variable>
 
+<!-- Parameter $locale-prefix -->
+<!--
+  This parameter specifies the prefix (can be empty) used in ISO 19139 language tags 
+-->
+
+  <xsl:param name="locale-prefix">locale-</xsl:param>
+
+<!-- Parameter $locale-default-lang -->
+<!--
+  This parameter specifies the default language tag used in ISO 19139 language tags 
+-->
+
+  <xsl:param name="locale-default-lang">en</xsl:param>
+
+
 <!-- Parameter $include-deprecated -->
 <!--
   This parameter specifies whether deprecated mappings must ("yes") or must not
   ("no") be included in the output.
 -->
-
 <!-- Uncomment to include deprecated mappings from the output -->
 
   <xsl:param name="include-deprecated">yes</xsl:param>
@@ -438,8 +452,8 @@
       <xsl:when test="$element/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString">
         <xsl:choose>
           <!-- Try to find English locale first -->
-          <xsl:when test="$element/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale='#locale-en']">
-            <xsl:value-of select="normalize-space($element/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale='#locale-en'][1])"/>
+	  <xsl:when test="$element/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale='#{$locale-prefix}{$locale-default-lang}']">
+	    <xsl:value-of select="normalize-space($element/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale='#${locale-prefix}{$locale-default-lang}'][1])"/>
           </xsl:when>
           <!-- Otherwise use the first available LocalisedCharacterString -->
           <xsl:otherwise>
@@ -4175,7 +4189,7 @@
       <xsl:variable name="value" select="normalize-space(.)"/>
       <xsl:variable name="langs">
         <xsl:call-template name="Alpha3-to-Alpha2">
-          <xsl:with-param name="lang" select="substring-after(translate(translate(@locale, $uppercase, $lowercase), '#', ''), 'locale-')"/>
+          <xsl:with-param name="lang" select="substring-after(translate(translate(@locale, $uppercase, $lowercase), '#', ''), $locale-prefix)"/>
         </xsl:call-template>
       </xsl:variable>
       <xsl:if test="$value != ''">

--- a/tests/test-cases/multilingual-metadata-locale/config.json
+++ b/tests/test-cases/multilingual-metadata-locale/config.json
@@ -1,0 +1,10 @@
+{
+    "description": "Configurable prefix for locale transformation test, issue #90",
+    "parameters": {
+        "profile": "extended",
+        "CoupledResourceLookup": "disabled",
+        "include-deprecated": "no",
+	"locale-prefix": "",
+	"locale-default-lang": "en"
+    }
+}

--- a/tests/test-cases/multilingual-metadata-locale/expected_output.rdf
+++ b/tests/test-cases/multilingual-metadata-locale/expected_output.rdf
@@ -1,0 +1,313 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:adms="http://www.w3.org/ns/adms#"
+         xmlns:cnt="http://www.w3.org/2011/content#"
+         xmlns:dc="http://purl.org/dc/elements/1.1/"
+         xmlns:dcat="http://www.w3.org/ns/dcat#"
+         xmlns:dcatap="http://data.europa.eu/r5r/"
+         xmlns:dct="http://purl.org/dc/terms/"
+         xmlns:dctype="http://purl.org/dc/dcmitype/"
+         xmlns:dqv="http://www.w3.org/ns/dqv#"
+         xmlns:foaf="http://xmlns.com/foaf/0.1/"
+         xmlns:geodcatap="http://data.europa.eu/930/"
+         xmlns:gsp="http://www.opengis.net/ont/geosparql#"
+         xmlns:local="urn:local"
+         xmlns:locn="http://www.w3.org/ns/locn#"
+         xmlns:org="http://www.w3.org/ns/org#"
+         xmlns:owl="http://www.w3.org/2002/07/owl#"
+         xmlns:prov="http://www.w3.org/ns/prov#"
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+         xmlns:schema="http://schema.org/"
+         xmlns:sdmx-attribute="http://purl.org/linked-data/sdmx/2009/attribute#"
+         xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+         xmlns:vcard="http://www.w3.org/2006/vcard/ns#">
+   <rdf:Description rdf:about="https://cuzk.cz/CZ-00025712-CUZK_ATOM_DATA50">
+      <foaf:isPrimaryTopicOf>
+         <rdf:Description>
+            <rdf:type rdf:resource="http://www.w3.org/ns/dcat#CatalogRecord"/>
+            <foaf:primaryTopic rdf:resource="https://cuzk.cz/CZ-00025712-CUZK_ATOM_DATA50"/>
+            <dct:conformsTo>
+               <dct:Standard rdf:about="http://data.europa.eu/930/"/>
+            </dct:conformsTo>
+            <dct:language>
+               <dct:LinguisticSystem rdf:about="http://publications.europa.eu/resource/authority/language/CZE"/>
+            </dct:language>
+            <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-03-06</dct:modified>
+            <dcat:contactPoint>
+               <rdf:Description>
+                  <rdf:type rdf:resource="http://www.w3.org/2006/vcard/ns#Individual"/>
+                  <vcard:fn xml:lang="cs">Vlček, Bohumil, Ing.</vcard:fn>
+                  <vcard:organization-name xml:lang="cs">Český úřad zeměměřický a katastrální</vcard:organization-name>
+                  <vcard:organization-name xml:lang="en">Czech Office for Surveying, Mapping and Cadastre</vcard:organization-name>
+                  <vcard:hasTelephone rdf:resource="tel:+420284044455"/>
+                  <vcard:hasEmail rdf:resource="mailto:bohumil.vlcek@cuzk.gov.cz"/>
+                  <vcard:hasEmail rdf:resource="mailto:podpora.zums@cuzk.gov.cz"/>
+                  <vcard:hasURL rdf:resource="https://geoportal.cuzk.gov.cz"/>
+                  <vcard:hasAddress>
+                     <vcard:Address>
+                        <vcard:street-address>Pod sídlištěm 1800/9</vcard:street-address>
+                        <vcard:locality>Praha 8</vcard:locality>
+                        <vcard:postal-code>182 11</vcard:postal-code>
+                        <vcard:country-name>Česká republika</vcard:country-name>
+                     </vcard:Address>
+                  </vcard:hasAddress>
+               </rdf:Description>
+            </dcat:contactPoint>
+            <prov:qualifiedAttribution>
+               <prov:Attribution>
+                  <prov:agent>
+                     <rdf:Description>
+                        <rdf:type rdf:resource="http://xmlns.com/foaf/0.1/Person"/>
+                        <rdf:type rdf:resource="http://www.w3.org/ns/prov#Agent"/>
+                        <foaf:name xml:lang="cs">Vlček, Bohumil, Ing.</foaf:name>
+                        <org:memberOf>
+                           <foaf:Organization>
+                              <foaf:name xml:lang="cs">Český úřad zeměměřický a katastrální</foaf:name>
+                              <foaf:name xml:lang="en">Czech Office for Surveying, Mapping and Cadastre</foaf:name>
+                           </foaf:Organization>
+                        </org:memberOf>
+                        <foaf:phone rdf:resource="tel:+420284044455"/>
+                        <foaf:mbox rdf:resource="mailto:bohumil.vlcek@cuzk.gov.cz"/>
+                        <foaf:mbox rdf:resource="mailto:podpora.zums@cuzk.gov.cz"/>
+                        <foaf:workplaceHomepage rdf:resource="https://geoportal.cuzk.gov.cz"/>
+                        <locn:address>
+                           <locn:Address>
+                              <locn:thoroughfare>Pod sídlištěm 1800/9</locn:thoroughfare>
+                              <locn:postName>Praha 8</locn:postName>
+                              <locn:postCode>182 11</locn:postCode>
+                              <locn:adminUnitL1>Česká republika</locn:adminUnitL1>
+                           </locn:Address>
+                        </locn:address>
+                     </rdf:Description>
+                  </prov:agent>
+                  <dcat:hadRole>
+                     <dcat:Role rdf:about="http://inspire.ec.europa.eu/metadata-codelist/ResponsiblePartyRole/pointOfContact"/>
+                  </dcat:hadRole>
+               </prov:Attribution>
+            </prov:qualifiedAttribution>
+            <dct:identifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CZ-CUZK-ATOM-DATA50</dct:identifier>
+            <dct:source rdf:parseType="Resource">
+               <rdf:type rdf:resource="http://www.w3.org/ns/dcat#CatalogRecord"/>
+               <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-03-06</dct:modified>
+               <cnt:characterEncoding rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UTF-8</cnt:characterEncoding>
+               <dct:conformsTo rdf:parseType="Resource">
+                  <rdf:type rdf:resource="http://purl.org/dc/terms/Standard"/>
+                  <dct:title xml:lang="cs">ISO 19119/INSPIRE_TG2/CZ4/CUZK</dct:title>
+                  <owl:versionInfo xml:lang="cs">2.0</owl:versionInfo>
+               </dct:conformsTo>
+            </dct:source>
+         </rdf:Description>
+      </foaf:isPrimaryTopicOf>
+      <rdf:type rdf:resource="http://www.w3.org/ns/dcat#DataService"/>
+      <geodcatap:resourceType rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/ResourceType/service"/>
+      <dct:title xml:lang="cs">Stahovací služba ATOM pro Data50</dct:title>
+      <dct:title xml:lang="en">ATOM Download Service for the Data50</dct:title>
+      <dct:description xml:lang="cs">Stahovací služba ATOM pro Data50 je veřejná stahovací služba pro poskytování dat digitálního geografického modelu Data50. Služba poskytuje data pro celou republiku ve formátu shapefile. Data se skládají z 8 tematických oblastí- Sídelní, kulturní a hospodářské objekty, Komunikace, Produktovody a elektrické vedení, Vodstvo, Hranice územních jednotek, Vegetace a povrch, Terénní reliéf a Popis. Služba splňuje technické pokyny pro INSPIRE stahovací služby verze 3.1. Pro stažení je datová sada komprimována (ZIP).</dct:description>
+      <dct:description xml:lang="en">The ATOM download service for Data50 is publicly available and it provides data of the geographical model Data50. The service provides data for the whole territory of the Czech Republic in shapefile data format. Data is divided into 8 thematic groups - Settlements and cultural and industrial buildings, Transportation, Pipelines and electric lines, Hydrography, Boundary of territorial units, Vegetation and bare surface, Terrain and Names. Data can be downloaded by thematic groups or all layers in one file. The service fulfills the technical instructions for INSPIRE Download Services in the version 3.1. Datasets are compressed (ZIP) for downloading.</dct:description>
+      <geodcatap:purpose xml:lang="cs">Služba byla vytvořena na základě směrnice o vybudování infrastruktury prostorových dat ve Společenství (INSPIRE), která vstoupila v platnost 15. května 2007. Do národní legislativy byla Směrnice v České republice transponována zákonem č. 380/2009 Sb., kterým se měnily zákon č. 123/1998 Sb., o právu na informace o životním prostředí, ve znění pozdějších předpisů, a zákon č. 200/1994 Sb., o zeměměřictví a o změně a doplnění některých zákonů souvisejících s jeho zavedením, ve znění pozdějších předpisů. Celá transpozice byla doplněna vyhláškou č. 103/2010 Sb., o provedení některých ustanovení zákona o poskytování informací o životním prostředí.</geodcatap:purpose>
+      <geodcatap:purpose xml:lang="en">Service was created on the the Directive on construction of spatial data infrastructure in the European Community (INSPIRE), which is valid from 15 May 2007. Into national legislation in the Czech Republic, the Directive was transposed by the Act No. 380/2009 Coll., amending Act No. 123/1998 Coll., establishing the right to information on the environment, as subsequently amended, and Act No. 200/1994 Coll., on surveying and amending and supplementing certain acts related to its introduction, as amended. Full transposition was supplemented by Decree No. 103/2010 Coll., implementing certain provisions of the Act to provide environmental information.</geodcatap:purpose>
+      <dcat:theme rdf:resource="http://inspire.ec.europa.eu/theme/tn"/>
+      <dcat:theme rdf:resource="http://inspire.ec.europa.eu/theme/hy"/>
+      <dcat:theme rdf:resource="http://inspire.ec.europa.eu/theme/au"/>
+      <dcat:theme rdf:resource="http://inspire.ec.europa.eu/theme/gn"/>
+      <dcat:theme rdf:resource="http://inspire.ec.europa.eu/theme/el"/>
+      <dcat:theme rdf:resource="http://inspire.ec.europa.eu/theme/bu"/>
+      <dcat:theme rdf:resource="https://www.slovnikcuzk.eu/termin.php?tid=4006&amp;l=administrativni-hranice"/>
+      <dcat:theme rdf:resource="https://www.slovnikcuzk.eu/termin.php?tid=4388&amp;l=dopravni-infrastruktura"/>
+      <dcat:theme rdf:resource="https://www.slovnikcuzk.eu/termin.php?tid=4477&amp;l=geograficke-nazvoslovi"/>
+      <dcat:theme rdf:resource="https://www.slovnikcuzk.eu/termin.php?tid=5452&amp;l=vedeni-technickeho-vybaveni--site-technickeho-vybaveni"/>
+      <dcat:theme rdf:resource="https://www.slovnikcuzk.eu/termin.php?tid=4151&amp;l=vyskopis"/>
+      <dcat:keyword xml:lang="cs">bezešvá databáze</dcat:keyword>
+      <dcat:keyword xml:lang="en">seamless database</dcat:keyword>
+      <dcat:keyword xml:lang="cs">topografická databáze</dcat:keyword>
+      <dcat:keyword xml:lang="en">topographic database</dcat:keyword>
+      <dcat:keyword xml:lang="cs">1:50 000</dcat:keyword>
+      <dcat:keyword xml:lang="en">1:50,000</dcat:keyword>
+      <dcat:keyword xml:lang="cs">1:500000</dcat:keyword>
+      <dcat:keyword xml:lang="en">1:500000</dcat:keyword>
+      <dcat:keyword xml:lang="cs">50 000</dcat:keyword>
+      <dcat:keyword xml:lang="en">50,000</dcat:keyword>
+      <dcat:keyword xml:lang="cs">50000</dcat:keyword>
+      <dcat:keyword xml:lang="en">50000</dcat:keyword>
+      <dcat:keyword xml:lang="cs">databáze České republiky</dcat:keyword>
+      <dcat:keyword xml:lang="en">database of the Czech Republic</dcat:keyword>
+      <dcat:keyword xml:lang="cs">doprava</dcat:keyword>
+      <dcat:keyword xml:lang="en">transportation</dcat:keyword>
+      <dcat:keyword xml:lang="cs">sídla</dcat:keyword>
+      <dcat:keyword xml:lang="en">settlements</dcat:keyword>
+      <dcat:keyword xml:lang="cs">vrstevnice</dcat:keyword>
+      <dcat:keyword xml:lang="en">contour</dcat:keyword>
+      <dcat:keyword xml:lang="cs">stahovací služba</dcat:keyword>
+      <dcat:keyword xml:lang="en">download service</dcat:keyword>
+      <dcat:keyword xml:lang="cs">stahování dat</dcat:keyword>
+      <dcat:keyword xml:lang="en">data downloading</dcat:keyword>
+      <dcat:keyword xml:lang="cs">ATOM</dcat:keyword>
+      <dcat:keyword xml:lang="en">ATOM</dcat:keyword>
+      <dcat:theme rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/infoProductAccessService"/>
+      <dct:identifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"/>
+      <geodcatap:serviceType rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/download"/>
+      <dct:spatial rdf:parseType="Resource">
+         <rdf:type rdf:resource="http://purl.org/dc/terms/Location"/>
+         <dcat:bbox rdf:datatype="http://www.opengis.net/ont/geosparql#wktLiteral"><![CDATA[POLYGON((12.09 51.06,18.86 51.06,18.86 48.55,12.09 48.55,12.09 51.06))]]></dcat:bbox>
+         <dcat:bbox rdf:datatype="http://www.opengis.net/ont/geosparql#gmlLiteral"><![CDATA[<gml:Envelope srsName="http://www.opengis.net/def/crs/OGC/1.3/CRS84"><gml:lowerCorner>12.09 48.55</gml:lowerCorner><gml:upperCorner>18.86 51.06</gml:upperCorner></gml:Envelope>]]></dcat:bbox>
+         <dcat:bbox rdf:datatype="http://www.opengis.net/ont/geosparql#geoJSONLiteral"><![CDATA[{"type":"Polygon","coordinates":[[[12.09,51.06],[18.86,51.06],[18.86,48.55],[12.09,48.55],[12.09,51.06]]]}]]></dcat:bbox>
+      </dct:spatial>
+      <dct:spatial>
+         <dct:Location rdf:about="http://publications.europa.eu/resource/authority/country/CZE"/>
+      </dct:spatial>
+      <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-03-27</dct:modified>
+      <dct:accessRights>
+         <dct:RightsStatement rdf:about="http://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess/noLimitations"/>
+      </dct:accessRights>
+      <dct:license>
+         <dct:LicenseDocument rdf:about="https://geoportal.cuzk.gov.cz/Dokumenty/Podminky.pdf"/>
+      </dct:license>
+      <dct:conformsTo>
+         <dct:Standard rdf:about="http://data.europa.eu/eli/reg/2009/976"/>
+      </dct:conformsTo>
+      <prov:wasUsedBy>
+         <prov:Activity>
+            <prov:used>
+               <prov:Entity rdf:about="https://cuzk.cz/CZ-00025712-CUZK_ATOM_DATA50"/>
+            </prov:used>
+            <prov:qualifiedAssociation rdf:parseType="Resource">
+               <rdf:type rdf:resource="http://www.w3.org/ns/prov#Association"/>
+               <prov:hadPlan rdf:parseType="Resource">
+                  <rdf:type rdf:resource="http://www.w3.org/ns/prov#Plan"/>
+                  <prov:wasDerivedFrom>
+                     <prov:Entity rdf:about="http://data.europa.eu/eli/reg/2009/976"/>
+                  </prov:wasDerivedFrom>
+               </prov:hadPlan>
+            </prov:qualifiedAssociation>
+            <prov:generated rdf:parseType="Resource">
+               <rdf:type rdf:resource="http://www.w3.org/ns/prov#Entity"/>
+               <dct:type rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/DegreeOfConformity/conformant"/>
+               <dct:description xml:lang="cs">Testování souladu síťové služby s prováděcími pravidly INSPIRE pro síťové služby.</dct:description>
+               <dct:description xml:lang="en">Network service conformity testing with INSPIRE implementing rules for network services.</dct:description>
+            </prov:generated>
+         </prov:Activity>
+      </prov:wasUsedBy>
+      <prov:wasUsedBy>
+         <prov:Activity>
+            <prov:used>
+               <prov:Entity rdf:about="https://cuzk.cz/CZ-00025712-CUZK_ATOM_DATA50"/>
+            </prov:used>
+            <prov:qualifiedAssociation rdf:parseType="Resource">
+               <rdf:type rdf:resource="http://www.w3.org/ns/prov#Association"/>
+               <prov:hadPlan rdf:parseType="Resource">
+                  <rdf:type rdf:resource="http://www.w3.org/ns/prov#Plan"/>
+                  <prov:wasDerivedFrom rdf:parseType="Resource">
+                     <rdf:type rdf:resource="http://www.w3.org/ns/prov#Entity"/>
+                     <dct:title xml:lang="cs">Technical Guidance for the implementation of INSPIRE Download Services</dct:title>
+                     <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2013-08-09</dct:issued>
+                  </prov:wasDerivedFrom>
+               </prov:hadPlan>
+            </prov:qualifiedAssociation>
+            <prov:generated rdf:parseType="Resource">
+               <rdf:type rdf:resource="http://www.w3.org/ns/prov#Entity"/>
+               <dct:type rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/DegreeOfConformity/conformant"/>
+               <dct:description xml:lang="cs">Testování souladu INSPIRE ATOM stahovací služby s technickými pokyny pro implementaci INSPIRE stahovacích služeb.</dct:description>
+               <dct:description xml:lang="en">INSPIRE ATOM download service conformity testing with the Technical Guidance for the implementation of INSPIRE Download Services.</dct:description>
+            </prov:generated>
+         </prov:Activity>
+      </prov:wasUsedBy>
+      <dct:conformsTo rdf:parseType="Resource">
+         <rdf:type rdf:resource="http://purl.org/dc/terms/Standard"/>
+         <dct:title xml:lang="cs">Technical Guidance for the implementation of INSPIRE Download Services</dct:title>
+         <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2013-08-09</dct:issued>
+      </dct:conformsTo>
+      <prov:wasUsedBy>
+         <prov:Activity>
+            <prov:used>
+               <prov:Entity rdf:about="https://cuzk.cz/CZ-00025712-CUZK_ATOM_DATA50"/>
+            </prov:used>
+            <prov:qualifiedAssociation rdf:parseType="Resource">
+               <rdf:type rdf:resource="http://www.w3.org/ns/prov#Association"/>
+               <prov:hadPlan rdf:parseType="Resource">
+                  <rdf:type rdf:resource="http://www.w3.org/ns/prov#Plan"/>
+                  <prov:wasDerivedFrom>
+                     <prov:Entity rdf:about="http://data.europa.eu/eli/reg/2009/976"/>
+                  </prov:wasDerivedFrom>
+               </prov:hadPlan>
+            </prov:qualifiedAssociation>
+            <prov:generated rdf:parseType="Resource">
+               <rdf:type rdf:resource="http://www.w3.org/ns/prov#Entity"/>
+               <dct:type rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/DegreeOfConformity/conformant"/>
+               <dct:description xml:lang="cs">Testování souladu síťové služby s prováděcími pravidly INSPIRE pro síťové služby.</dct:description>
+               <dct:description xml:lang="en">Network service conformity testing with INSPIRE implementing rules for network services.</dct:description>
+            </prov:generated>
+         </prov:Activity>
+      </prov:wasUsedBy>
+      <prov:wasUsedBy>
+         <prov:Activity>
+            <prov:used>
+               <prov:Entity rdf:about="https://cuzk.cz/CZ-00025712-CUZK_ATOM_DATA50"/>
+            </prov:used>
+            <prov:qualifiedAssociation rdf:parseType="Resource">
+               <rdf:type rdf:resource="http://www.w3.org/ns/prov#Association"/>
+               <prov:hadPlan rdf:parseType="Resource">
+                  <rdf:type rdf:resource="http://www.w3.org/ns/prov#Plan"/>
+                  <prov:wasDerivedFrom rdf:parseType="Resource">
+                     <rdf:type rdf:resource="http://www.w3.org/ns/prov#Entity"/>
+                     <dct:title xml:lang="cs">Technical Guidance for the implementation of INSPIRE Download Services</dct:title>
+                     <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2013-08-09</dct:issued>
+                  </prov:wasDerivedFrom>
+               </prov:hadPlan>
+            </prov:qualifiedAssociation>
+            <prov:generated rdf:parseType="Resource">
+               <rdf:type rdf:resource="http://www.w3.org/ns/prov#Entity"/>
+               <dct:type rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/DegreeOfConformity/conformant"/>
+               <dct:description xml:lang="cs">Testování souladu INSPIRE ATOM stahovací služby s technickými pokyny pro implementaci INSPIRE stahovacích služeb.</dct:description>
+               <dct:description xml:lang="en">INSPIRE ATOM download service conformity testing with the Technical Guidance for the implementation of INSPIRE Download Services.</dct:description>
+            </prov:generated>
+         </prov:Activity>
+      </prov:wasUsedBy>
+      <dcat:endpointURL rdf:resource="https://atom.cuzk.gov.cz/Data50/Data50.xml"/>
+      <dcat:endpointDescription rdf:resource="https://atom.cuzk.gov.cz/Data50/Data50.xml"/>
+      <geodcatap:custodian>
+         <rdf:Description>
+            <rdf:type rdf:resource="http://xmlns.com/foaf/0.1/Organization"/>
+            <rdf:type rdf:resource="http://www.w3.org/ns/prov#Agent"/>
+            <foaf:name xml:lang="cs">Český úřad zeměměřický a katastrální</foaf:name>
+            <foaf:name xml:lang="en">Czech Office for Surveying, Mapping and Cadastre</foaf:name>
+            <foaf:phone rdf:resource="tel:+420284044455"/>
+            <foaf:mbox rdf:resource="mailto:cuzk.helpdesk@cuzk.gov.cz"/>
+            <foaf:workplaceHomepage rdf:resource="https://geoportal.cuzk.gov.cz"/>
+            <locn:address>
+               <locn:Address>
+                  <locn:thoroughfare>Pod sídlištěm 1800/9</locn:thoroughfare>
+                  <locn:postName>Praha 8</locn:postName>
+                  <locn:postCode>182 11</locn:postCode>
+                  <locn:adminUnitL1>Česká republika</locn:adminUnitL1>
+               </locn:Address>
+            </locn:address>
+         </rdf:Description>
+      </geodcatap:custodian>
+      <prov:qualifiedAttribution>
+         <prov:Attribution>
+            <prov:agent>
+               <rdf:Description>
+                  <rdf:type rdf:resource="http://xmlns.com/foaf/0.1/Organization"/>
+                  <rdf:type rdf:resource="http://www.w3.org/ns/prov#Agent"/>
+                  <foaf:name xml:lang="cs">Český úřad zeměměřický a katastrální</foaf:name>
+                  <foaf:name xml:lang="en">Czech Office for Surveying, Mapping and Cadastre</foaf:name>
+                  <foaf:phone rdf:resource="tel:+420284044455"/>
+                  <foaf:mbox rdf:resource="mailto:cuzk.helpdesk@cuzk.gov.cz"/>
+                  <foaf:workplaceHomepage rdf:resource="https://geoportal.cuzk.gov.cz"/>
+                  <locn:address>
+                     <locn:Address>
+                        <locn:thoroughfare>Pod sídlištěm 1800/9</locn:thoroughfare>
+                        <locn:postName>Praha 8</locn:postName>
+                        <locn:postCode>182 11</locn:postCode>
+                        <locn:adminUnitL1>Česká republika</locn:adminUnitL1>
+                     </locn:Address>
+                  </locn:address>
+               </rdf:Description>
+            </prov:agent>
+            <dcat:hadRole>
+               <dcat:Role rdf:about="http://inspire.ec.europa.eu/metadata-codelist/ResponsiblePartyRole/custodian"/>
+            </dcat:hadRole>
+         </prov:Attribution>
+      </prov:qualifiedAttribution>
+   </rdf:Description>
+</rdf:RDF>

--- a/tests/test-cases/multilingual-metadata-locale/expected_output.ttl
+++ b/tests/test-cases/multilingual-metadata-locale/expected_output.ttl
@@ -1,0 +1,202 @@
+@prefix cnt: <http://www.w3.org/2011/content#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+@prefix geodcatap: <http://data.europa.eu/930/> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+geodcatap: a dcterms:Standard .
+
+<http://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess/noLimitations> a dcterms:RightsStatement .
+
+<http://inspire.ec.europa.eu/metadata-codelist/ResponsiblePartyRole/custodian> a dcat:Role .
+
+<http://inspire.ec.europa.eu/metadata-codelist/ResponsiblePartyRole/pointOfContact> a dcat:Role .
+
+<http://publications.europa.eu/resource/authority/country/CZE> a dcterms:Location .
+
+<http://publications.europa.eu/resource/authority/language/CZE> a dcterms:LinguisticSystem .
+
+<https://geoportal.cuzk.gov.cz/Dokumenty/Podminky.pdf> a dcterms:LicenseDocument .
+
+<http://data.europa.eu/eli/reg/2009/976> a dcterms:Standard,
+        prov:Entity .
+
+<https://cuzk.cz/CZ-00025712-CUZK_ATOM_DATA50> a dcat:DataService,
+        prov:Entity ;
+    geodcatap:custodian [ a prov:Agent,
+                foaf:Organization ;
+            locn:address [ a locn:Address ;
+                    locn:adminUnitL1 "Česká republika" ;
+                    locn:postCode "182 11" ;
+                    locn:postName "Praha 8" ;
+                    locn:thoroughfare "Pod sídlištěm 1800/9" ] ;
+            foaf:mbox <mailto:cuzk.helpdesk@cuzk.gov.cz> ;
+            foaf:name "Český úřad zeměměřický a katastrální"@cs,
+                "Czech Office for Surveying, Mapping and Cadastre"@en ;
+            foaf:phone <tel:+420284044455> ;
+            foaf:workplaceHomepage <https://geoportal.cuzk.gov.cz> ] ;
+    geodcatap:purpose "Služba byla vytvořena na základě směrnice o vybudování infrastruktury prostorových dat ve Společenství (INSPIRE), která vstoupila v platnost 15. května 2007. Do národní legislativy byla Směrnice v České republice transponována zákonem č. 380/2009 Sb., kterým se měnily zákon č. 123/1998 Sb., o právu na informace o životním prostředí, ve znění pozdějších předpisů, a zákon č. 200/1994 Sb., o zeměměřictví a o změně a doplnění některých zákonů souvisejících s jeho zavedením, ve znění pozdějších předpisů. Celá transpozice byla doplněna vyhláškou č. 103/2010 Sb., o provedení některých ustanovení zákona o poskytování informací o životním prostředí."@cs,
+        "Service was created on the the Directive on construction of spatial data infrastructure in the European Community (INSPIRE), which is valid from 15 May 2007. Into national legislation in the Czech Republic, the Directive was transposed by the Act No. 380/2009 Coll., amending Act No. 123/1998 Coll., establishing the right to information on the environment, as subsequently amended, and Act No. 200/1994 Coll., on surveying and amending and supplementing certain acts related to its introduction, as amended. Full transposition was supplemented by Decree No. 103/2010 Coll., implementing certain provisions of the Act to provide environmental information."@en ;
+    geodcatap:resourceType <http://inspire.ec.europa.eu/metadata-codelist/ResourceType/service> ;
+    geodcatap:serviceType <http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/download> ;
+    dcterms:accessRights <http://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess/noLimitations> ;
+    dcterms:conformsTo [ a dcterms:Standard ;
+            dcterms:issued "2013-08-09"^^xsd:date ;
+            dcterms:title "Technical Guidance for the implementation of INSPIRE Download Services"@cs ],
+        <http://data.europa.eu/eli/reg/2009/976> ;
+    dcterms:description "Stahovací služba ATOM pro Data50 je veřejná stahovací služba pro poskytování dat digitálního geografického modelu Data50. Služba poskytuje data pro celou republiku ve formátu shapefile. Data se skládají z 8 tematických oblastí- Sídelní, kulturní a hospodářské objekty, Komunikace, Produktovody a elektrické vedení, Vodstvo, Hranice územních jednotek, Vegetace a povrch, Terénní reliéf a Popis. Služba splňuje technické pokyny pro INSPIRE stahovací služby verze 3.1. Pro stažení je datová sada komprimována (ZIP)."@cs,
+        "The ATOM download service for Data50 is publicly available and it provides data of the geographical model Data50. The service provides data for the whole territory of the Czech Republic in shapefile data format. Data is divided into 8 thematic groups - Settlements and cultural and industrial buildings, Transportation, Pipelines and electric lines, Hydrography, Boundary of territorial units, Vegetation and bare surface, Terrain and Names. Data can be downloaded by thematic groups or all layers in one file. The service fulfills the technical instructions for INSPIRE Download Services in the version 3.1. Datasets are compressed (ZIP) for downloading."@en ;
+    dcterms:identifier ""^^xsd:string ;
+    dcterms:license <https://geoportal.cuzk.gov.cz/Dokumenty/Podminky.pdf> ;
+    dcterms:modified "2023-03-27"^^xsd:date ;
+    dcterms:spatial [ a dcterms:Location ;
+            dcat:bbox "{\"type\":\"Polygon\",\"coordinates\":[[[12.09,51.06],[18.86,51.06],[18.86,48.55],[12.09,48.55],[12.09,51.06]]]}"^^geo:geoJSONLiteral,
+                "<gml:Envelope srsName=\"http://www.opengis.net/def/crs/OGC/1.3/CRS84\"><gml:lowerCorner>12.09 48.55</gml:lowerCorner><gml:upperCorner>18.86 51.06</gml:upperCorner></gml:Envelope>"^^geo:gmlLiteral,
+                "POLYGON((12.09 51.06,18.86 51.06,18.86 48.55,12.09 48.55,12.09 51.06))"^^geo:wktLiteral ],
+        <http://publications.europa.eu/resource/authority/country/CZE> ;
+    dcterms:title "Stahovací služba ATOM pro Data50"@cs,
+        "ATOM Download Service for the Data50"@en ;
+    dcat:endpointDescription <https://atom.cuzk.gov.cz/Data50/Data50.xml> ;
+    dcat:endpointURL <https://atom.cuzk.gov.cz/Data50/Data50.xml> ;
+    dcat:keyword "1:50 000"@cs,
+        "1:500000"@cs,
+        "50 000"@cs,
+        "50000"@cs,
+        "ATOM"@cs,
+        "bezešvá databáze"@cs,
+        "databáze České republiky"@cs,
+        "doprava"@cs,
+        "stahovací služba"@cs,
+        "stahování dat"@cs,
+        "sídla"@cs,
+        "topografická databáze"@cs,
+        "vrstevnice"@cs,
+        "1:50,000"@en,
+        "1:500000"@en,
+        "50,000"@en,
+        "50000"@en,
+        "ATOM"@en,
+        "contour"@en,
+        "data downloading"@en,
+        "database of the Czech Republic"@en,
+        "download service"@en,
+        "seamless database"@en,
+        "settlements"@en,
+        "topographic database"@en,
+        "transportation"@en ;
+    dcat:theme <http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/infoProductAccessService>,
+        <http://inspire.ec.europa.eu/theme/au>,
+        <http://inspire.ec.europa.eu/theme/bu>,
+        <http://inspire.ec.europa.eu/theme/el>,
+        <http://inspire.ec.europa.eu/theme/gn>,
+        <http://inspire.ec.europa.eu/theme/hy>,
+        <http://inspire.ec.europa.eu/theme/tn>,
+        <https://www.slovnikcuzk.eu/termin.php?tid=4006&l=administrativni-hranice>,
+        <https://www.slovnikcuzk.eu/termin.php?tid=4151&l=vyskopis>,
+        <https://www.slovnikcuzk.eu/termin.php?tid=4388&l=dopravni-infrastruktura>,
+        <https://www.slovnikcuzk.eu/termin.php?tid=4477&l=geograficke-nazvoslovi>,
+        <https://www.slovnikcuzk.eu/termin.php?tid=5452&l=vedeni-technickeho-vybaveni--site-technickeho-vybaveni> ;
+    prov:qualifiedAttribution [ a prov:Attribution ;
+            dcat:hadRole <http://inspire.ec.europa.eu/metadata-codelist/ResponsiblePartyRole/custodian> ;
+            prov:agent [ a prov:Agent,
+                        foaf:Organization ;
+                    locn:address [ a locn:Address ;
+                            locn:adminUnitL1 "Česká republika" ;
+                            locn:postCode "182 11" ;
+                            locn:postName "Praha 8" ;
+                            locn:thoroughfare "Pod sídlištěm 1800/9" ] ;
+                    foaf:mbox <mailto:cuzk.helpdesk@cuzk.gov.cz> ;
+                    foaf:name "Český úřad zeměměřický a katastrální"@cs,
+                        "Czech Office for Surveying, Mapping and Cadastre"@en ;
+                    foaf:phone <tel:+420284044455> ;
+                    foaf:workplaceHomepage <https://geoportal.cuzk.gov.cz> ] ] ;
+    prov:wasUsedBy [ a prov:Activity ;
+            prov:generated [ a prov:Entity ;
+                    dcterms:description "Testování souladu INSPIRE ATOM stahovací služby s technickými pokyny pro implementaci INSPIRE stahovacích služeb."@cs,
+                        "INSPIRE ATOM download service conformity testing with the Technical Guidance for the implementation of INSPIRE Download Services."@en ;
+                    dcterms:type <http://inspire.ec.europa.eu/metadata-codelist/DegreeOfConformity/conformant> ] ;
+            prov:qualifiedAssociation [ a prov:Association ;
+                    prov:hadPlan [ a prov:Plan ;
+                            prov:wasDerivedFrom [ a prov:Entity ;
+                                    dcterms:issued "2013-08-09"^^xsd:date ;
+                                    dcterms:title "Technical Guidance for the implementation of INSPIRE Download Services"@cs ] ] ] ;
+            prov:used <https://cuzk.cz/CZ-00025712-CUZK_ATOM_DATA50> ],
+        [ a prov:Activity ;
+            prov:generated [ a prov:Entity ;
+                    dcterms:description "Testování souladu síťové služby s prováděcími pravidly INSPIRE pro síťové služby."@cs,
+                        "Network service conformity testing with INSPIRE implementing rules for network services."@en ;
+                    dcterms:type <http://inspire.ec.europa.eu/metadata-codelist/DegreeOfConformity/conformant> ] ;
+            prov:qualifiedAssociation [ a prov:Association ;
+                    prov:hadPlan [ a prov:Plan ;
+                            prov:wasDerivedFrom <http://data.europa.eu/eli/reg/2009/976> ] ] ;
+            prov:used <https://cuzk.cz/CZ-00025712-CUZK_ATOM_DATA50> ],
+        [ a prov:Activity ;
+            prov:generated [ a prov:Entity ;
+                    dcterms:description "Testování souladu INSPIRE ATOM stahovací služby s technickými pokyny pro implementaci INSPIRE stahovacích služeb."@cs,
+                        "INSPIRE ATOM download service conformity testing with the Technical Guidance for the implementation of INSPIRE Download Services."@en ;
+                    dcterms:type <http://inspire.ec.europa.eu/metadata-codelist/DegreeOfConformity/conformant> ] ;
+            prov:qualifiedAssociation [ a prov:Association ;
+                    prov:hadPlan [ a prov:Plan ;
+                            prov:wasDerivedFrom [ a prov:Entity ;
+                                    dcterms:issued "2013-08-09"^^xsd:date ;
+                                    dcterms:title "Technical Guidance for the implementation of INSPIRE Download Services"@cs ] ] ] ;
+            prov:used <https://cuzk.cz/CZ-00025712-CUZK_ATOM_DATA50> ],
+        [ a prov:Activity ;
+            prov:generated [ a prov:Entity ;
+                    dcterms:description "Testování souladu síťové služby s prováděcími pravidly INSPIRE pro síťové služby."@cs,
+                        "Network service conformity testing with INSPIRE implementing rules for network services."@en ;
+                    dcterms:type <http://inspire.ec.europa.eu/metadata-codelist/DegreeOfConformity/conformant> ] ;
+            prov:qualifiedAssociation [ a prov:Association ;
+                    prov:hadPlan [ a prov:Plan ;
+                            prov:wasDerivedFrom <http://data.europa.eu/eli/reg/2009/976> ] ] ;
+            prov:used <https://cuzk.cz/CZ-00025712-CUZK_ATOM_DATA50> ] ;
+    foaf:isPrimaryTopicOf [ a dcat:CatalogRecord ;
+            dcterms:conformsTo geodcatap: ;
+            dcterms:identifier "CZ-CUZK-ATOM-DATA50"^^xsd:string ;
+            dcterms:language <http://publications.europa.eu/resource/authority/language/CZE> ;
+            dcterms:modified "2025-03-06"^^xsd:date ;
+            dcterms:source [ a dcat:CatalogRecord ;
+                    dcterms:conformsTo [ a dcterms:Standard ;
+                            dcterms:title "ISO 19119/INSPIRE_TG2/CZ4/CUZK"@cs ;
+                            owl:versionInfo "2.0"@cs ] ;
+                    dcterms:modified "2025-03-06"^^xsd:date ;
+                    cnt:characterEncoding "UTF-8"^^xsd:string ] ;
+            dcat:contactPoint [ a vcard:Individual ;
+                    vcard:fn "Vlček, Bohumil, Ing."@cs ;
+                    vcard:hasAddress [ a vcard:Address ;
+                            vcard:country-name "Česká republika" ;
+                            vcard:locality "Praha 8" ;
+                            vcard:postal-code "182 11" ;
+                            vcard:street-address "Pod sídlištěm 1800/9" ] ;
+                    vcard:hasEmail <mailto:bohumil.vlcek@cuzk.gov.cz>,
+                        <mailto:podpora.zums@cuzk.gov.cz> ;
+                    vcard:hasTelephone <tel:+420284044455> ;
+                    vcard:hasURL <https://geoportal.cuzk.gov.cz> ;
+                    vcard:organization-name "Český úřad zeměměřický a katastrální"@cs,
+                        "Czech Office for Surveying, Mapping and Cadastre"@en ] ;
+            prov:qualifiedAttribution [ a prov:Attribution ;
+                    dcat:hadRole <http://inspire.ec.europa.eu/metadata-codelist/ResponsiblePartyRole/pointOfContact> ;
+                    prov:agent [ a prov:Agent,
+                                foaf:Person ;
+                            locn:address [ a locn:Address ;
+                                    locn:adminUnitL1 "Česká republika" ;
+                                    locn:postCode "182 11" ;
+                                    locn:postName "Praha 8" ;
+                                    locn:thoroughfare "Pod sídlištěm 1800/9" ] ;
+                            org:memberOf [ a foaf:Organization ;
+                                    foaf:name "Český úřad zeměměřický a katastrální"@cs,
+                                        "Czech Office for Surveying, Mapping and Cadastre"@en ] ;
+                            foaf:mbox <mailto:bohumil.vlcek@cuzk.gov.cz>,
+                                <mailto:podpora.zums@cuzk.gov.cz> ;
+                            foaf:name "Vlček, Bohumil, Ing."@cs ;
+                            foaf:phone <tel:+420284044455> ;
+                            foaf:workplaceHomepage <https://geoportal.cuzk.gov.cz> ] ] ;
+            foaf:primaryTopic <https://cuzk.cz/CZ-00025712-CUZK_ATOM_DATA50> ] .
+

--- a/tests/test-cases/multilingual-metadata-locale/input.xml
+++ b/tests/test-cases/multilingual-metadata-locale/input.xml
@@ -1,0 +1,855 @@
+<?xml version="1.0" encoding="utf-8"?>
+<csw:GetRecordByIdResponse xsi:schemaLocation="http://www.opengis.net/cat/csw/2.0.2 http://schemas.opengis.net/csw/2.0.2/CSW-discovery.xsd" xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:ows="http://www.opengis.net/ows" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<gmd:MD_Metadata xsi:schemaLocation="http://www.isotc211.org/2005/gmd https://inspire.ec.europa.eu/draft-schemas/inspire-md-schemas-temp/apiso-inspire/apiso-inspire.xsd" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:srv="http://www.isotc211.org/2005/srv" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+		<gmd:fileIdentifier>
+			<gco:CharacterString>CZ-CUZK-ATOM-DATA50</gco:CharacterString>
+		</gmd:fileIdentifier>
+		<gmd:language>
+			<gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="cze">cze</gmd:LanguageCode>
+		</gmd:language>
+		<gmd:characterSet>
+			<gmd:MD_CharacterSetCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8">utf8</gmd:MD_CharacterSetCode>
+		</gmd:characterSet>
+		<gmd:parentIdentifier>
+			<gco:CharacterString/>
+		</gmd:parentIdentifier>
+		<gmd:hierarchyLevel>
+			<gmd:MD_ScopeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_ScopeCode" codeListValue="service">service</gmd:MD_ScopeCode>
+		</gmd:hierarchyLevel>
+		<gmd:hierarchyLevelName>
+			<gco:CharacterString>služba</gco:CharacterString>
+		</gmd:hierarchyLevelName>
+		<gmd:hierarchyLevelName>
+			<gco:CharacterString>META_ATOM-Data50_SERVICE</gco:CharacterString>
+		</gmd:hierarchyLevelName>
+		<gmd:contact>
+			<gmd:CI_ResponsibleParty>
+				<gmd:individualName>
+					<gco:CharacterString>Vlček, Bohumil, Ing.</gco:CharacterString>
+				</gmd:individualName>
+				<gmd:organisationName xsi:type="gmd:PT_FreeText_PropertyType">
+					<gco:CharacterString>Český úřad zeměměřický a katastrální</gco:CharacterString>
+					<gmd:PT_FreeText>
+						<gmd:textGroup>
+							<gmd:LocalisedCharacterString locale="#EN">Czech Office for Surveying, Mapping and Cadastre</gmd:LocalisedCharacterString>
+						</gmd:textGroup>
+					</gmd:PT_FreeText>
+				</gmd:organisationName>
+				<gmd:contactInfo>
+					<gmd:CI_Contact>
+						<gmd:phone>
+							<gmd:CI_Telephone>
+								<gmd:voice>
+									<gco:CharacterString>+420 284 044 455</gco:CharacterString>
+								</gmd:voice>
+								<gmd:facsimile>
+									<gco:CharacterString>+420 284 041 557</gco:CharacterString>
+								</gmd:facsimile>
+							</gmd:CI_Telephone>
+						</gmd:phone>
+						<gmd:address>
+							<gmd:CI_Address>
+								<gmd:deliveryPoint>
+									<gmx:Anchor xlink:href="https://linked.cuzk.cz/resource/ruian/adresni-misto/25133616">Pod sídlištěm 1800/9</gmx:Anchor>
+								</gmd:deliveryPoint>
+								<gmd:city>
+									<gco:CharacterString>Praha 8</gco:CharacterString>
+								</gmd:city>
+								<gmd:postalCode>
+									<gco:CharacterString>182 11</gco:CharacterString>
+								</gmd:postalCode>
+								<gmd:country xsi:type="gmd:PT_FreeText_PropertyType">
+									<gmx:Anchor xlink:href="http://publications.europa.eu/resource/authority/country/CZE">Česká republika</gmx:Anchor>
+									<gmd:PT_FreeText>
+										<gmd:textGroup>
+											<gmd:LocalisedCharacterString locale="#EN">Czech Republic</gmd:LocalisedCharacterString>
+										</gmd:textGroup>
+									</gmd:PT_FreeText>
+								</gmd:country>
+								<gmd:electronicMailAddress>
+									<gco:CharacterString>bohumil.vlcek@cuzk.gov.cz</gco:CharacterString>
+								</gmd:electronicMailAddress>
+								<gmd:electronicMailAddress>
+									<gco:CharacterString>podpora.zums@cuzk.gov.cz</gco:CharacterString>
+								</gmd:electronicMailAddress>
+							</gmd:CI_Address>
+						</gmd:address>
+						<gmd:onlineResource>
+							<gmd:CI_OnlineResource>
+								<gmd:linkage>
+									<gmd:URL>https://geoportal.cuzk.gov.cz</gmd:URL>
+								</gmd:linkage>
+							</gmd:CI_OnlineResource>
+						</gmd:onlineResource>
+						<gmd:hoursOfService xsi:type="gmd:PT_FreeText_PropertyType">
+							<gco:CharacterString>Po-Pá 7-17 CET</gco:CharacterString>
+							<gmd:PT_FreeText>
+								<gmd:textGroup>
+									<gmd:LocalisedCharacterString locale="#EN">Mo-Fr 7:00 AM - 5:00 PM CET</gmd:LocalisedCharacterString>
+								</gmd:textGroup>
+							</gmd:PT_FreeText>
+						</gmd:hoursOfService>
+						<gmd:contactInstructions>
+							<gco:CharacterString/>
+						</gmd:contactInstructions>
+					</gmd:CI_Contact>
+				</gmd:contactInfo>
+				<gmd:role>
+					<gmd:CI_RoleCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_RoleCode" codeListValue="pointOfContact">pointOfContact</gmd:CI_RoleCode>
+				</gmd:role>
+			</gmd:CI_ResponsibleParty>
+		</gmd:contact>
+		<gmd:dateStamp>
+			<gco:Date>2025-03-06</gco:Date>
+		</gmd:dateStamp>
+		<gmd:metadataStandardName>
+			<gco:CharacterString>ISO 19119/INSPIRE_TG2/CZ4/CUZK</gco:CharacterString>
+		</gmd:metadataStandardName>
+		<gmd:metadataStandardVersion>
+			<gco:CharacterString>2.0</gco:CharacterString>
+		</gmd:metadataStandardVersion>
+		<gmd:locale>
+			<gmd:PT_Locale id="EN">
+				<gmd:languageCode>
+					<gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="eng">eng</gmd:LanguageCode>
+				</gmd:languageCode>
+				<gmd:country>
+					<gmd:Country codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#Country" codeListValue="GB">GB</gmd:Country>
+				</gmd:country>
+				<gmd:characterEncoding>
+					<gmd:MD_CharacterSetCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8">utf8</gmd:MD_CharacterSetCode>
+				</gmd:characterEncoding>
+			</gmd:PT_Locale>
+		</gmd:locale>
+		<gmd:identificationInfo>
+			<srv:SV_ServiceIdentification id="CZ-CUZK-ATOM-DATA50">
+				<gmd:citation>
+					<gmd:CI_Citation>
+						<gmd:title xsi:type="gmd:PT_FreeText_PropertyType">
+							<gco:CharacterString>Stahovací služba ATOM pro Data50</gco:CharacterString>
+							<gmd:PT_FreeText>
+								<gmd:textGroup>
+									<gmd:LocalisedCharacterString locale="#EN">ATOM Download Service for the Data50</gmd:LocalisedCharacterString>
+								</gmd:textGroup>
+							</gmd:PT_FreeText>
+						</gmd:title>
+						<gmd:alternateTitle xsi:type="gmd:PT_FreeText_PropertyType">
+							<gco:CharacterString>Služba stahování dat ATOM - Data50</gco:CharacterString>
+							<gmd:PT_FreeText>
+								<gmd:textGroup>
+									<gmd:LocalisedCharacterString locale="#EN">ATOM Download Service - Data50</gmd:LocalisedCharacterString>
+								</gmd:textGroup>
+							</gmd:PT_FreeText>
+						</gmd:alternateTitle>
+						<gmd:date>
+							<gmd:CI_Date>
+								<gmd:date>
+									<gco:Date>2023-03-27</gco:Date>
+								</gmd:date>
+								<gmd:dateType>
+									<gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision">revision</gmd:CI_DateTypeCode>
+								</gmd:dateType>
+							</gmd:CI_Date>
+						</gmd:date>
+						<gmd:identifier>
+							<gmd:MD_Identifier>
+								<gmd:code>
+									<gmx:Anchor xlink:href="https://cuzk.cz/CZ-00025712-CUZK_ATOM_DATA50">https://cuzk.cz/CZ-00025712-CUZK_ATOM_DATA50</gmx:Anchor>
+								</gmd:code>
+							</gmd:MD_Identifier>
+						</gmd:identifier>
+						<gmd:citedResponsibleParty>
+							<gmd:CI_ResponsibleParty>
+								<gmd:organisationName xsi:type="gmd:PT_FreeText_PropertyType">
+									<gco:CharacterString>Český úřad zeměměřický a katastrální</gco:CharacterString>
+									<gmd:PT_FreeText>
+										<gmd:textGroup>
+											<gmd:LocalisedCharacterString locale="#EN">Czech Office for Surveying, Mapping and Cadastre</gmd:LocalisedCharacterString>
+										</gmd:textGroup>
+									</gmd:PT_FreeText>
+								</gmd:organisationName>
+								<gmd:contactInfo>
+									<gmd:CI_Contact>
+										<gmd:hoursOfService>
+											<gco:CharacterString/>
+										</gmd:hoursOfService>
+										<gmd:contactInstructions>
+											<gco:CharacterString/>
+										</gmd:contactInstructions>
+									</gmd:CI_Contact>
+								</gmd:contactInfo>
+								<gmd:role>
+									<gmd:CI_RoleCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_RoleCode" codeListValue="custodian">custodian</gmd:CI_RoleCode>
+								</gmd:role>
+							</gmd:CI_ResponsibleParty>
+						</gmd:citedResponsibleParty>
+					</gmd:CI_Citation>
+				</gmd:citation>
+				<gmd:abstract xsi:type="gmd:PT_FreeText_PropertyType">
+					<gco:CharacterString>Stahovací služba ATOM pro Data50 je veřejná stahovací služba pro poskytování dat digitálního geografického modelu Data50. Služba poskytuje data pro celou republiku ve formátu shapefile. Data se skládají z 8 tematických oblastí- Sídelní, kulturní a hospodářské objekty, Komunikace, Produktovody a elektrické vedení, Vodstvo, Hranice územních jednotek, Vegetace a povrch, Terénní reliéf a Popis. Služba splňuje technické pokyny pro INSPIRE stahovací služby verze 3.1. Pro stažení je datová sada komprimována (ZIP).</gco:CharacterString>
+					<gmd:PT_FreeText>
+						<gmd:textGroup>
+							<gmd:LocalisedCharacterString locale="#EN">The ATOM download service for Data50 is publicly available and it provides data of the geographical model Data50. The service provides data for the whole territory of the Czech Republic in shapefile data format. Data is divided into 8 thematic groups - Settlements and cultural and industrial buildings, Transportation, Pipelines and electric lines, Hydrography, Boundary of territorial units, Vegetation and bare surface, Terrain and Names. Data can be downloaded by thematic groups or all layers in one file. The service fulfills the technical instructions for INSPIRE Download Services in the version 3.1. Datasets are compressed (ZIP) for downloading.</gmd:LocalisedCharacterString>
+						</gmd:textGroup>
+					</gmd:PT_FreeText>
+				</gmd:abstract>
+				<gmd:purpose xsi:type="gmd:PT_FreeText_PropertyType">
+					<gco:CharacterString>Služba byla vytvořena na základě směrnice o vybudování infrastruktury prostorových dat ve Společenství (INSPIRE), která vstoupila v platnost 15. května 2007. Do národní legislativy byla Směrnice v České republice transponována zákonem č. 380/2009 Sb., kterým se měnily zákon č. 123/1998 Sb., o právu na informace o životním prostředí, ve znění pozdějších předpisů, a zákon č. 200/1994 Sb., o zeměměřictví a o změně a doplnění některých zákonů souvisejících s jeho zavedením, ve znění pozdějších předpisů. Celá transpozice byla doplněna vyhláškou č. 103/2010 Sb., o provedení některých ustanovení zákona o poskytování informací o životním prostředí.</gco:CharacterString>
+					<gmd:PT_FreeText>
+						<gmd:textGroup>
+							<gmd:LocalisedCharacterString locale="#EN">Service was created on the the Directive on construction of spatial data infrastructure in the European Community (INSPIRE), which is valid from 15 May 2007. Into national legislation in the Czech Republic, the Directive was transposed by the Act No. 380/2009 Coll., amending Act No. 123/1998 Coll., establishing the right to information on the environment, as subsequently amended, and Act No. 200/1994 Coll., on surveying and amending and supplementing certain acts related to its introduction, as amended. Full transposition was supplemented by Decree No. 103/2010 Coll., implementing certain provisions of the Act to provide environmental information.</gmd:LocalisedCharacterString>
+						</gmd:textGroup>
+					</gmd:PT_FreeText>
+				</gmd:purpose>
+				<gmd:pointOfContact>
+					<gmd:CI_ResponsibleParty>
+						<gmd:individualName>
+							<gco:CharacterString/>
+						</gmd:individualName>
+						<gmd:organisationName xsi:type="gmd:PT_FreeText_PropertyType">
+							<gco:CharacterString>Český úřad zeměměřický a katastrální</gco:CharacterString>
+							<gmd:PT_FreeText>
+								<gmd:textGroup>
+									<gmd:LocalisedCharacterString locale="#EN">Czech Office for Surveying, Mapping and Cadastre</gmd:LocalisedCharacterString>
+								</gmd:textGroup>
+							</gmd:PT_FreeText>
+						</gmd:organisationName>
+						<gmd:contactInfo>
+							<gmd:CI_Contact>
+								<gmd:phone>
+									<gmd:CI_Telephone>
+										<gmd:voice>
+											<gco:CharacterString>+420 284 044 455</gco:CharacterString>
+										</gmd:voice>
+										<gmd:facsimile>
+											<gco:CharacterString>+420 284 041 557</gco:CharacterString>
+										</gmd:facsimile>
+									</gmd:CI_Telephone>
+								</gmd:phone>
+								<gmd:address>
+									<gmd:CI_Address>
+										<gmd:deliveryPoint>
+											<gmx:Anchor xlink:href="https://linked.cuzk.cz/resource/ruian/adresni-misto/25133616">Pod sídlištěm 1800/9</gmx:Anchor>
+										</gmd:deliveryPoint>
+										<gmd:city>
+											<gco:CharacterString>Praha 8</gco:CharacterString>
+										</gmd:city>
+										<gmd:postalCode>
+											<gco:CharacterString>182 11</gco:CharacterString>
+										</gmd:postalCode>
+										<gmd:country xsi:type="gmd:PT_FreeText_PropertyType">
+											<gmx:Anchor xlink:href="http://publications.europa.eu/resource/authority/country/CZE">Česká republika</gmx:Anchor>
+											<gmd:PT_FreeText>
+												<gmd:textGroup>
+													<gmd:LocalisedCharacterString locale="#EN">Czech Republic</gmd:LocalisedCharacterString>
+												</gmd:textGroup>
+											</gmd:PT_FreeText>
+										</gmd:country>
+										<gmd:electronicMailAddress>
+											<gco:CharacterString>cuzk.helpdesk@cuzk.gov.cz</gco:CharacterString>
+										</gmd:electronicMailAddress>
+									</gmd:CI_Address>
+								</gmd:address>
+								<gmd:onlineResource>
+									<gmd:CI_OnlineResource>
+										<gmd:linkage>
+											<gmd:URL>https://geoportal.cuzk.gov.cz</gmd:URL>
+										</gmd:linkage>
+									</gmd:CI_OnlineResource>
+								</gmd:onlineResource>
+								<gmd:hoursOfService xsi:type="gmd:PT_FreeText_PropertyType">
+									<gco:CharacterString>Po - Pá 7-17 CET</gco:CharacterString>
+									<gmd:PT_FreeText>
+										<gmd:textGroup>
+											<gmd:LocalisedCharacterString locale="#EN">Mo-Fr 7:00 AM - 5:00 PM CET</gmd:LocalisedCharacterString>
+										</gmd:textGroup>
+									</gmd:PT_FreeText>
+								</gmd:hoursOfService>
+								<gmd:contactInstructions>
+									<gco:CharacterString/>
+								</gmd:contactInstructions>
+							</gmd:CI_Contact>
+						</gmd:contactInfo>
+						<gmd:role>
+							<gmd:CI_RoleCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_RoleCode" codeListValue="custodian">custodian</gmd:CI_RoleCode>
+						</gmd:role>
+					</gmd:CI_ResponsibleParty>
+				</gmd:pointOfContact>
+				<gmd:descriptiveKeywords>
+					<gmd:MD_Keywords>
+						<gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+							<gmx:Anchor xlink:href="http://inspire.ec.europa.eu/theme/tn">Dopravní sítě</gmx:Anchor>
+							<gmd:PT_FreeText>
+								<gmd:textGroup>
+									<gmd:LocalisedCharacterString locale="#EN">Transport networks</gmd:LocalisedCharacterString>
+								</gmd:textGroup>
+							</gmd:PT_FreeText>
+						</gmd:keyword>
+						<gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+							<gmx:Anchor xlink:href="http://inspire.ec.europa.eu/theme/hy">Vodopis</gmx:Anchor>
+							<gmd:PT_FreeText>
+								<gmd:textGroup>
+									<gmd:LocalisedCharacterString locale="#EN">Hydrography</gmd:LocalisedCharacterString>
+								</gmd:textGroup>
+							</gmd:PT_FreeText>
+						</gmd:keyword>
+						<gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+							<gmx:Anchor xlink:href="http://inspire.ec.europa.eu/theme/au">Správní jednotky</gmx:Anchor>
+							<gmd:PT_FreeText>
+								<gmd:textGroup>
+									<gmd:LocalisedCharacterString locale="#EN">Administrative units</gmd:LocalisedCharacterString>
+								</gmd:textGroup>
+							</gmd:PT_FreeText>
+						</gmd:keyword>
+						<gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+							<gmx:Anchor xlink:href="http://inspire.ec.europa.eu/theme/gn">Zeměpisné názvy</gmx:Anchor>
+							<gmd:PT_FreeText>
+								<gmd:textGroup>
+									<gmd:LocalisedCharacterString locale="#EN">Geographical names</gmd:LocalisedCharacterString>
+								</gmd:textGroup>
+							</gmd:PT_FreeText>
+						</gmd:keyword>
+						<gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+							<gmx:Anchor xlink:href="http://inspire.ec.europa.eu/theme/el">Nadmořská výška</gmx:Anchor>
+							<gmd:PT_FreeText>
+								<gmd:textGroup>
+									<gmd:LocalisedCharacterString locale="#EN">Elevation</gmd:LocalisedCharacterString>
+								</gmd:textGroup>
+							</gmd:PT_FreeText>
+						</gmd:keyword>
+						<gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+							<gmx:Anchor xlink:href="http://inspire.ec.europa.eu/theme/bu">Budovy</gmx:Anchor>
+							<gmd:PT_FreeText>
+								<gmd:textGroup>
+									<gmd:LocalisedCharacterString locale="#EN">Buildings</gmd:LocalisedCharacterString>
+								</gmd:textGroup>
+							</gmd:PT_FreeText>
+						</gmd:keyword>
+						<gmd:thesaurusName>
+							<gmd:CI_Citation>
+								<gmd:title>
+									<gmx:Anchor xlink:href="http://www.eionet.europa.eu/gemet/inspire_themes">GEMET - INSPIRE themes, version 1.0</gmx:Anchor>
+								</gmd:title>
+								<gmd:date>
+									<gmd:CI_Date>
+										<gmd:date>
+											<gco:Date>2008-06-01</gco:Date>
+										</gmd:date>
+										<gmd:dateType>
+											<gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication">publication</gmd:CI_DateTypeCode>
+										</gmd:dateType>
+									</gmd:CI_Date>
+								</gmd:date>
+								<gmd:citedResponsibleParty>
+									<gmd:CI_ResponsibleParty>
+										<gmd:organisationName>
+											<gco:CharacterString>Joint Research Centre</gco:CharacterString>
+										</gmd:organisationName>
+										<gmd:role>
+											<gmd:CI_RoleCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_RoleCode" codeListValue="pointOfContact">pointOfContact</gmd:CI_RoleCode>
+										</gmd:role>
+									</gmd:CI_ResponsibleParty>
+								</gmd:citedResponsibleParty>
+							</gmd:CI_Citation>
+						</gmd:thesaurusName>
+					</gmd:MD_Keywords>
+				</gmd:descriptiveKeywords>
+				<gmd:descriptiveKeywords>
+					<gmd:MD_Keywords>
+						<gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+							<gmx:Anchor xlink:href="https://www.slovnikcuzk.eu/termin.php?tid=4006&amp;l=administrativni-hranice">administrativní hranice</gmx:Anchor>
+							<gmd:PT_FreeText>
+								<gmd:textGroup>
+									<gmd:LocalisedCharacterString locale="#EN">administrative boundary</gmd:LocalisedCharacterString>
+								</gmd:textGroup>
+							</gmd:PT_FreeText>
+						</gmd:keyword>
+						<gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+							<gmx:Anchor xlink:href="https://www.slovnikcuzk.eu/termin.php?tid=4388&amp;l=dopravni-infrastruktura">dopravní infrastruktura</gmx:Anchor>
+							<gmd:PT_FreeText>
+								<gmd:textGroup>
+									<gmd:LocalisedCharacterString locale="#EN">infrastructure of traffic</gmd:LocalisedCharacterString>
+								</gmd:textGroup>
+							</gmd:PT_FreeText>
+						</gmd:keyword>
+						<gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+							<gmx:Anchor xlink:href="https://www.slovnikcuzk.eu/termin.php?tid=4477&amp;l=geograficke-nazvoslovi">geografické názvosloví</gmx:Anchor>
+							<gmd:PT_FreeText>
+								<gmd:textGroup>
+									<gmd:LocalisedCharacterString locale="#EN">geographical names, geographic names (US)</gmd:LocalisedCharacterString>
+								</gmd:textGroup>
+							</gmd:PT_FreeText>
+						</gmd:keyword>
+						<gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+							<gmx:Anchor xlink:href="https://www.slovnikcuzk.eu/termin.php?tid=5452&amp;l=vedeni-technickeho-vybaveni--site-technickeho-vybaveni">vedení technického vybavení, sítě technického vybavení</gmx:Anchor>
+							<gmd:PT_FreeText>
+								<gmd:textGroup>
+									<gmd:LocalisedCharacterString locale="#EN">utilitity line</gmd:LocalisedCharacterString>
+								</gmd:textGroup>
+							</gmd:PT_FreeText>
+						</gmd:keyword>
+						<gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+							<gmx:Anchor xlink:href="https://www.slovnikcuzk.eu/termin.php?tid=4151&amp;l=vyskopis">výškopis</gmx:Anchor>
+							<gmd:PT_FreeText>
+								<gmd:textGroup>
+									<gmd:LocalisedCharacterString locale="#EN">hypsography</gmd:LocalisedCharacterString>
+								</gmd:textGroup>
+							</gmd:PT_FreeText>
+						</gmd:keyword>
+						<gmd:thesaurusName>
+							<gmd:CI_Citation>
+								<gmd:title xsi:type="gmd:PT_FreeText_PropertyType">
+									<gmx:Anchor xlink:href="https://www.slovnikcuzk.eu/">Terminologický slovník zeměměřictví a katastru nemovitostí</gmx:Anchor>
+									<gmd:PT_FreeText>
+										<gmd:textGroup>
+											<gmd:LocalisedCharacterString locale="#EN">Terminological Dictionary of Land Surveying and Cadastre of Real Estate</gmd:LocalisedCharacterString>
+										</gmd:textGroup>
+									</gmd:PT_FreeText>
+								</gmd:title>
+								<gmd:date>
+									<gmd:CI_Date>
+										<gmd:date>
+											<gco:Date>2009-01-01</gco:Date>
+										</gmd:date>
+										<gmd:dateType>
+											<gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication">publication</gmd:CI_DateTypeCode>
+										</gmd:dateType>
+									</gmd:CI_Date>
+								</gmd:date>
+								<gmd:citedResponsibleParty>
+									<gmd:CI_ResponsibleParty>
+										<gmd:organisationName xsi:type="gmd:PT_FreeText_PropertyType">
+											<gco:CharacterString>Český úřad zeměměřický a katastrální</gco:CharacterString>
+											<gmd:PT_FreeText>
+												<gmd:textGroup>
+													<gmd:LocalisedCharacterString locale="#EN">Czech Office for Surveying, Mapping and Cadastre</gmd:LocalisedCharacterString>
+												</gmd:textGroup>
+											</gmd:PT_FreeText>
+										</gmd:organisationName>
+										<gmd:role>
+											<gmd:CI_RoleCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_RoleCode" codeListValue="pointOfContact">pointOfContact</gmd:CI_RoleCode>
+										</gmd:role>
+									</gmd:CI_ResponsibleParty>
+								</gmd:citedResponsibleParty>
+							</gmd:CI_Citation>
+						</gmd:thesaurusName>
+					</gmd:MD_Keywords>
+				</gmd:descriptiveKeywords>
+				<gmd:descriptiveKeywords>
+					<gmd:MD_Keywords>
+						<gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+							<gco:CharacterString>bezešvá databáze</gco:CharacterString>
+							<gmd:PT_FreeText>
+								<gmd:textGroup>
+									<gmd:LocalisedCharacterString locale="#EN">seamless database</gmd:LocalisedCharacterString>
+								</gmd:textGroup>
+							</gmd:PT_FreeText>
+						</gmd:keyword>
+						<gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+							<gco:CharacterString>topografická databáze</gco:CharacterString>
+							<gmd:PT_FreeText>
+								<gmd:textGroup>
+									<gmd:LocalisedCharacterString locale="#EN">topographic database</gmd:LocalisedCharacterString>
+								</gmd:textGroup>
+							</gmd:PT_FreeText>
+						</gmd:keyword>
+						<gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+							<gco:CharacterString>1:50 000</gco:CharacterString>
+							<gmd:PT_FreeText>
+								<gmd:textGroup>
+									<gmd:LocalisedCharacterString locale="#EN">1:50,000</gmd:LocalisedCharacterString>
+								</gmd:textGroup>
+							</gmd:PT_FreeText>
+						</gmd:keyword>
+						<gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+							<gco:CharacterString>1:500000</gco:CharacterString>
+							<gmd:PT_FreeText>
+								<gmd:textGroup>
+									<gmd:LocalisedCharacterString locale="#EN">1:500000</gmd:LocalisedCharacterString>
+								</gmd:textGroup>
+							</gmd:PT_FreeText>
+						</gmd:keyword>
+						<gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+							<gco:CharacterString>50 000</gco:CharacterString>
+							<gmd:PT_FreeText>
+								<gmd:textGroup>
+									<gmd:LocalisedCharacterString locale="#EN">50,000</gmd:LocalisedCharacterString>
+								</gmd:textGroup>
+							</gmd:PT_FreeText>
+						</gmd:keyword>
+						<gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+							<gco:CharacterString>50000</gco:CharacterString>
+							<gmd:PT_FreeText>
+								<gmd:textGroup>
+									<gmd:LocalisedCharacterString locale="#EN">50000</gmd:LocalisedCharacterString>
+								</gmd:textGroup>
+							</gmd:PT_FreeText>
+						</gmd:keyword>
+						<gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+							<gco:CharacterString>databáze České republiky</gco:CharacterString>
+							<gmd:PT_FreeText>
+								<gmd:textGroup>
+									<gmd:LocalisedCharacterString locale="#EN">database of the Czech Republic</gmd:LocalisedCharacterString>
+								</gmd:textGroup>
+							</gmd:PT_FreeText>
+						</gmd:keyword>
+						<gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+							<gco:CharacterString>doprava</gco:CharacterString>
+							<gmd:PT_FreeText>
+								<gmd:textGroup>
+									<gmd:LocalisedCharacterString locale="#EN">transportation</gmd:LocalisedCharacterString>
+								</gmd:textGroup>
+							</gmd:PT_FreeText>
+						</gmd:keyword>
+						<gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+							<gco:CharacterString>sídla</gco:CharacterString>
+							<gmd:PT_FreeText>
+								<gmd:textGroup>
+									<gmd:LocalisedCharacterString locale="#EN">settlements</gmd:LocalisedCharacterString>
+								</gmd:textGroup>
+							</gmd:PT_FreeText>
+						</gmd:keyword>
+						<gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+							<gco:CharacterString>vrstevnice</gco:CharacterString>
+							<gmd:PT_FreeText>
+								<gmd:textGroup>
+									<gmd:LocalisedCharacterString locale="#EN">contour</gmd:LocalisedCharacterString>
+								</gmd:textGroup>
+							</gmd:PT_FreeText>
+						</gmd:keyword>
+						<gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+							<gco:CharacterString>stahovací služba</gco:CharacterString>
+							<gmd:PT_FreeText>
+								<gmd:textGroup>
+									<gmd:LocalisedCharacterString locale="#EN">download service</gmd:LocalisedCharacterString>
+								</gmd:textGroup>
+							</gmd:PT_FreeText>
+						</gmd:keyword>
+						<gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+							<gco:CharacterString>stahování dat</gco:CharacterString>
+							<gmd:PT_FreeText>
+								<gmd:textGroup>
+									<gmd:LocalisedCharacterString locale="#EN">data downloading</gmd:LocalisedCharacterString>
+								</gmd:textGroup>
+							</gmd:PT_FreeText>
+						</gmd:keyword>
+						<gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+							<gco:CharacterString>ATOM</gco:CharacterString>
+							<gmd:PT_FreeText>
+								<gmd:textGroup>
+									<gmd:LocalisedCharacterString locale="#EN">ATOM</gmd:LocalisedCharacterString>
+								</gmd:textGroup>
+							</gmd:PT_FreeText>
+						</gmd:keyword>
+					</gmd:MD_Keywords>
+				</gmd:descriptiveKeywords>
+				<gmd:descriptiveKeywords>
+					<gmd:MD_Keywords>
+						<gmd:keyword>
+							<gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/infoProductAccessService">infoProductAccessService</gmx:Anchor>
+						</gmd:keyword>
+						<gmd:thesaurusName>
+							<gmd:CI_Citation>
+								<gmd:title>
+									<gmx:Anchor xlink:href="http://data.europa.eu/eli/reg/2008/1205">COMMISSION REGULATION (EC) No 1205/2008 of 3 December 2008 implementing Directive 2007/2/EC of the European Partilament and of the Council as regards metadata, Part D 4, Classification of Spatial Data Services</gmx:Anchor>
+								</gmd:title>
+								<gmd:date>
+									<gmd:CI_Date>
+										<gmd:date>
+											<gco:Date>2008-12-03</gco:Date>
+										</gmd:date>
+										<gmd:dateType>
+											<gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication">publication</gmd:CI_DateTypeCode>
+										</gmd:dateType>
+									</gmd:CI_Date>
+								</gmd:date>
+							</gmd:CI_Citation>
+						</gmd:thesaurusName>
+					</gmd:MD_Keywords>
+				</gmd:descriptiveKeywords>
+				<gmd:resourceConstraints>
+					<gmd:MD_LegalConstraints>
+						<gmd:accessConstraints>
+							<gmd:MD_RestrictionCode codeListValue="otherRestrictions" codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode">otherRestrictions</gmd:MD_RestrictionCode>
+						</gmd:accessConstraints>
+						<gmd:otherConstraints xsi:type="gmd:PT_FreeText_PropertyType">
+							<gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess/noLimitations">Bez omezení veřejného přístupu</gmx:Anchor>
+							<gmd:PT_FreeText>
+								<gmd:textGroup>
+									<gmd:LocalisedCharacterString locale="#EN">No limitations to public access</gmd:LocalisedCharacterString>
+								</gmd:textGroup>
+							</gmd:PT_FreeText>
+						</gmd:otherConstraints>
+					</gmd:MD_LegalConstraints>
+				</gmd:resourceConstraints>
+				<gmd:resourceConstraints>
+					<gmd:MD_LegalConstraints>
+						<gmd:useConstraints>
+							<gmd:MD_RestrictionCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode" codeListValue="otherRestrictions">otherRestrictions</gmd:MD_RestrictionCode>
+						</gmd:useConstraints>
+						<gmd:otherConstraints xsi:type="gmd:PT_FreeText_PropertyType">
+							<gmx:Anchor xlink:href="https://geoportal.cuzk.gov.cz/Dokumenty/Podminky.pdf">Zásady užívání dat a služeb ZÚ</gmx:Anchor>
+							<gmd:PT_FreeText>
+								<gmd:textGroup>
+									<gmd:LocalisedCharacterString locale="#EN">Data and Services Use Policy</gmd:LocalisedCharacterString>
+								</gmd:textGroup>
+							</gmd:PT_FreeText>
+						</gmd:otherConstraints>
+					</gmd:MD_LegalConstraints>
+				</gmd:resourceConstraints>
+				<srv:serviceType>
+					<gco:LocalName codeSpace="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType">download</gco:LocalName>
+				</srv:serviceType>
+				<srv:serviceTypeVersion>
+					<gco:CharacterString>3.1</gco:CharacterString>
+				</srv:serviceTypeVersion>
+				<srv:extent>
+					<gmd:EX_Extent>
+						<gmd:description xsi:type="gmd:PT_FreeText_PropertyType">
+							<gco:CharacterString>100% území České Republiky, tj. 78 870 km2 (k 31. 12. 2016).</gco:CharacterString>
+							<gmd:PT_FreeText>
+								<gmd:textGroup>
+									<gmd:LocalisedCharacterString locale="#EN">100% area of the Czech Republic, i.e. 78 870 km2 (to 31st December 2016).</gmd:LocalisedCharacterString>
+								</gmd:textGroup>
+							</gmd:PT_FreeText>
+						</gmd:description>
+						<gmd:geographicElement>
+							<gmd:EX_GeographicBoundingBox>
+								<gmd:westBoundLongitude>
+									<gco:Decimal>12.09</gco:Decimal>
+								</gmd:westBoundLongitude>
+								<gmd:eastBoundLongitude>
+									<gco:Decimal>18.86</gco:Decimal>
+								</gmd:eastBoundLongitude>
+								<gmd:southBoundLatitude>
+									<gco:Decimal>48.55</gco:Decimal>
+								</gmd:southBoundLatitude>
+								<gmd:northBoundLatitude>
+									<gco:Decimal>51.06</gco:Decimal>
+								</gmd:northBoundLatitude>
+							</gmd:EX_GeographicBoundingBox>
+						</gmd:geographicElement>
+						<gmd:geographicElement>
+							<gmd:EX_GeographicDescription>
+								<gmd:geographicIdentifier>
+									<gmd:RS_Identifier>
+										<gmd:code>
+											<gmx:Anchor xlink:href="http://publications.europa.eu/resource/authority/country/CZE">ČR</gmx:Anchor>
+										</gmd:code>
+									</gmd:RS_Identifier>
+								</gmd:geographicIdentifier>
+							</gmd:EX_GeographicDescription>
+						</gmd:geographicElement>
+					</gmd:EX_Extent>
+				</srv:extent>
+				<srv:couplingType>
+					<srv:SV_CouplingType codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#SV_CouplingType" codeListValue="tight">tight</srv:SV_CouplingType>
+				</srv:couplingType>
+				<srv:containsOperations>
+					<srv:SV_OperationMetadata>
+						<srv:operationName>
+							<gco:CharacterString>getDownloadServiceMetadata</gco:CharacterString>
+						</srv:operationName>
+						<srv:DCP>
+							<srv:DCPList codeList="http://www.isotc211.org/2005/iso19119/resources/codelist/gmxCodelists.xml#DCPList" codeListValue="WebServices">WebServices</srv:DCPList>
+						</srv:DCP>
+						<srv:connectPoint>
+							<gmd:CI_OnlineResource>
+								<gmd:linkage>
+									<gmd:URL>https://atom.cuzk.gov.cz/Data50/Data50.xml</gmd:URL>
+								</gmd:linkage>
+							</gmd:CI_OnlineResource>
+						</srv:connectPoint>
+					</srv:SV_OperationMetadata>
+				</srv:containsOperations>
+				<srv:containsOperations>
+					<srv:SV_OperationMetadata>
+						<srv:operationName>
+							<gco:CharacterString>Get Spatial Dataset</gco:CharacterString>
+						</srv:operationName>
+						<srv:DCP>
+							<srv:DCPList codeList="http://www.isotc211.org/2005/iso19119/resources/codelist/gmxCodelists.xml#DCPList" codeListValue="WebServices">WebServices</srv:DCPList>
+						</srv:DCP>
+						<srv:connectPoint>
+							<gmd:CI_OnlineResource>
+								<gmd:linkage>
+									<gmd:URL>https://atom.cuzk.gov.cz/get.ashx?theme=Data50</gmd:URL>
+								</gmd:linkage>
+							</gmd:CI_OnlineResource>
+						</srv:connectPoint>
+					</srv:SV_OperationMetadata>
+				</srv:containsOperations>
+				<srv:containsOperations>
+					<srv:SV_OperationMetadata>
+						<srv:operationName>
+							<gco:CharacterString>Describe Spatial Dataset</gco:CharacterString>
+						</srv:operationName>
+						<srv:DCP>
+							<srv:DCPList codeList="http://www.isotc211.org/2005/iso19119/resources/codelist/gmxCodelists.xml#DCPList" codeListValue="WebServices">WebServices</srv:DCPList>
+						</srv:DCP>
+						<srv:connectPoint>
+							<gmd:CI_OnlineResource>
+								<gmd:linkage>
+									<gmd:URL>https://atom.cuzk.gov.cz/describe.ashx?theme=Data50</gmd:URL>
+								</gmd:linkage>
+							</gmd:CI_OnlineResource>
+						</srv:connectPoint>
+					</srv:SV_OperationMetadata>
+				</srv:containsOperations>
+				<srv:operatesOn xlink:href="https://geoportal.cuzk.gov.cz/SDIProCSW/service.svc/get?REQUEST=GetRecordById&amp;SERVICE=CSW&amp;VERSION=2.0.2&amp;OUTPUTSCHEMA=http://www.isotc211.org/2005/gmd&amp;ELEMENTSETNAME=full&amp;Id=CZ-CUZK-DATA50-V" xlink:title="Metadata série datových sad Data50" xlink:type="simple"/>
+			</srv:SV_ServiceIdentification>
+		</gmd:identificationInfo>
+		<gmd:distributionInfo>
+			<gmd:MD_Distribution>
+				<gmd:distributionFormat>
+					<gmd:MD_Format>
+						<gmd:name>
+							<gmx:Anchor xlink:href="https://www.iana.org/assignments/media-types/application/vnd.shp">SHP</gmx:Anchor>
+						</gmd:name>
+						<gmd:version gco:nilReason="unknown"/>
+						<gmd:specification>
+							<gco:CharacterString/>
+						</gmd:specification>
+					</gmd:MD_Format>
+				</gmd:distributionFormat>
+				<gmd:transferOptions>
+					<gmd:MD_DigitalTransferOptions>
+						<gmd:unitsOfDistribution xsi:type="gmd:PT_FreeText_PropertyType">
+							<gco:CharacterString>Území celé ČR</gco:CharacterString>
+							<gmd:PT_FreeText>
+								<gmd:textGroup>
+									<gmd:LocalisedCharacterString locale="#EN">Area of the Czech Republic</gmd:LocalisedCharacterString>
+								</gmd:textGroup>
+							</gmd:PT_FreeText>
+						</gmd:unitsOfDistribution>
+						<gmd:onLine>
+							<gmd:CI_OnlineResource>
+								<gmd:linkage>
+									<gmd:URL>https://atom.cuzk.gov.cz/Data50/Data50.xml</gmd:URL>
+								</gmd:linkage>
+								<gmd:protocol>
+									<gmx:Anchor xlink:href="https://tools.ietf.org/html/rfc4287">atom</gmx:Anchor>
+								</gmd:protocol>
+							</gmd:CI_OnlineResource>
+						</gmd:onLine>
+					</gmd:MD_DigitalTransferOptions>
+				</gmd:transferOptions>
+			</gmd:MD_Distribution>
+		</gmd:distributionInfo>
+		<gmd:dataQualityInfo>
+			<gmd:DQ_DataQuality>
+				<gmd:scope>
+					<gmd:DQ_Scope>
+						<gmd:level>
+							<gmd:MD_ScopeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_ScopeCode" codeListValue="service">service</gmd:MD_ScopeCode>
+						</gmd:level>
+						<gmd:levelDescription>
+							<gmd:MD_ScopeDescription>
+								<gmd:other>
+									<gco:CharacterString>služba</gco:CharacterString>
+								</gmd:other>
+							</gmd:MD_ScopeDescription>
+						</gmd:levelDescription>
+					</gmd:DQ_Scope>
+				</gmd:scope>
+				<gmd:report>
+					<gmd:DQ_DomainConsistency xsi:type="gmd:DQ_DomainConsistency_Type">
+						<gmd:measureIdentification>
+							<gmd:MD_Identifier>
+								<gmd:code>
+									<gco:CharacterString>CZ-00025712-CUZK_ATOM_Data50-DQ_DomainConsistency-1</gco:CharacterString>
+								</gmd:code>
+							</gmd:MD_Identifier>
+						</gmd:measureIdentification>
+						<gmd:result>
+							<gmd:DQ_ConformanceResult>
+								<gmd:specification>
+									<gmd:CI_Citation>
+										<gmd:title>
+											<gmx:Anchor xlink:href="http://data.europa.eu/eli/reg/2009/976">Nařízení Komise (ES) č. 976/2009 ze dne 19. října 2009, kterým se provádí směrnice Evropského parlamentu a Rady 2007/2/ES, pokud jde o síťové služby</gmx:Anchor>
+										</gmd:title>
+										<gmd:alternateTitle>
+											<gco:CharacterString>COMMISSION REGULATION (EC) No 976/2009 of 19 October 2009 implementing Directive 2007/2/EC of the European Parliament and of the Council as regards the Network Services</gco:CharacterString>
+										</gmd:alternateTitle>
+										<gmd:date>
+											<gmd:CI_Date>
+												<gmd:date>
+													<gco:Date>2009-10-20</gco:Date>
+												</gmd:date>
+												<gmd:dateType>
+													<gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication">publication</gmd:CI_DateTypeCode>
+												</gmd:dateType>
+											</gmd:CI_Date>
+										</gmd:date>
+									</gmd:CI_Citation>
+								</gmd:specification>
+								<gmd:explanation xsi:type="gmd:PT_FreeText_PropertyType">
+									<gco:CharacterString>Testování souladu síťové služby s prováděcími pravidly INSPIRE pro síťové služby.</gco:CharacterString>
+									<gmd:PT_FreeText>
+										<gmd:textGroup>
+											<gmd:LocalisedCharacterString locale="#EN">Network service conformity testing with INSPIRE implementing rules for network services.</gmd:LocalisedCharacterString>
+										</gmd:textGroup>
+									</gmd:PT_FreeText>
+								</gmd:explanation>
+								<gmd:pass>
+									<gco:Boolean>true</gco:Boolean>
+								</gmd:pass>
+							</gmd:DQ_ConformanceResult>
+						</gmd:result>
+					</gmd:DQ_DomainConsistency>
+				</gmd:report>
+				<gmd:report>
+					<gmd:DQ_DomainConsistency xsi:type="gmd:DQ_DomainConsistency_Type">
+						<gmd:measureIdentification>
+							<gmd:MD_Identifier>
+								<gmd:code>
+									<gco:CharacterString>CZ-00025712-CUZK_ATOM_INSPIRE_Data50-DQ_DomainConsistency-2</gco:CharacterString>
+								</gmd:code>
+							</gmd:MD_Identifier>
+						</gmd:measureIdentification>
+						<gmd:result>
+							<gmd:DQ_ConformanceResult>
+								<gmd:specification>
+									<gmd:CI_Citation>
+										<gmd:title>
+											<gco:CharacterString>Technical Guidance for the implementation of INSPIRE Download Services</gco:CharacterString>
+										</gmd:title>
+										<gmd:alternateTitle xsi:type="gmd:PT_FreeText_PropertyType">
+											<gco:CharacterString>Technické pokyny pro implementaci INSPIRE služeb stahování dat</gco:CharacterString>
+											<gmd:PT_FreeText>
+												<gmd:textGroup>
+													<gmd:LocalisedCharacterString locale="#EN">Technical Guidance for the implementation of INSPIRE Download Services</gmd:LocalisedCharacterString>
+												</gmd:textGroup>
+											</gmd:PT_FreeText>
+										</gmd:alternateTitle>
+										<gmd:date>
+											<gmd:CI_Date>
+												<gmd:date>
+													<gco:Date>2013-08-09</gco:Date>
+												</gmd:date>
+												<gmd:dateType>
+													<gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication">publication</gmd:CI_DateTypeCode>
+												</gmd:dateType>
+											</gmd:CI_Date>
+										</gmd:date>
+									</gmd:CI_Citation>
+								</gmd:specification>
+								<gmd:explanation xsi:type="gmd:PT_FreeText_PropertyType">
+									<gco:CharacterString>Testování souladu INSPIRE ATOM stahovací služby s technickými pokyny pro implementaci INSPIRE stahovacích služeb.</gco:CharacterString>
+									<gmd:PT_FreeText>
+										<gmd:textGroup>
+											<gmd:LocalisedCharacterString locale="#EN">INSPIRE ATOM download service conformity testing with the Technical Guidance for the implementation of INSPIRE Download Services.</gmd:LocalisedCharacterString>
+										</gmd:textGroup>
+									</gmd:PT_FreeText>
+								</gmd:explanation>
+								<gmd:pass>
+									<gco:Boolean>true</gco:Boolean>
+								</gmd:pass>
+							</gmd:DQ_ConformanceResult>
+						</gmd:result>
+					</gmd:DQ_DomainConsistency>
+				</gmd:report>
+			</gmd:DQ_DataQuality>
+		</gmd:dataQualityInfo>
+	</gmd:MD_Metadata>
+</csw:GetRecordByIdResponse>


### PR DESCRIPTION
Make the language tag in multilingual character strings configurable, using a "locale-prefix" and a "locale-default-lang" parameter. 

The default behavior is to still use 'locale-en' as the default setting, but it can also be set to e.g. empty prefix and uppercase 'EN' (which is used by at least some geonetwork instances in Belgium)