### PR TITLE
Improve localisation handling, coordinate formatting and deprecated mappings

### DIFF
--- a/iso-19139-to-dcat-ap.xsl
+++ b/iso-19139-to-dcat-ap.xsl
@@ -451,9 +451,17 @@
       <!-- Handle PT_FreeText with LocalisedCharacterStrings -->
       <xsl:when test="$element/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString">
         <xsl:choose>
-          <!-- Try to find English locale first -->
-          <xsl:when test="$element/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale='#{$locale-prefix}{$locale-default-lang}']">
-            <xsl:value-of select="normalize-space($element/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale='#${locale-prefix}{$locale-default-lang}'][1])"/>
+          <!-- Try to find English locale with prefix (e.g. #locale-en) -->
+          <xsl:when test="$element/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#',$locale-prefix,$locale-default-lang)]">
+            <xsl:value-of select="normalize-space($element/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#',$locale-prefix,$locale-default-lang)][1])"/>
+          </xsl:when>
+          <!-- Try to find English locale without prefix, uppercase (e.g. #EN) -->
+          <xsl:when test="$element/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#',upper-case($locale-default-lang))]">
+            <xsl:value-of select="normalize-space($element/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#',upper-case($locale-default-lang))][1])"/>
+          </xsl:when>
+          <!-- Try to find English locale without prefix, lowercase (e.g. #en) -->
+          <xsl:when test="$element/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#',lower-case($locale-default-lang))]">
+            <xsl:value-of select="normalize-space($element/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#',lower-case($locale-default-lang))][1])"/>
           </xsl:when>
           <!-- Otherwise use the first available LocalisedCharacterString -->
           <xsl:otherwise>
@@ -768,9 +776,7 @@
         </xsl:otherwise>
       </xsl:choose>
     </xsl:param>
-    <xsl:param name="ServiceCategory">
-      <xsl:value-of select="gmd:identificationInfo/*/gmd:descriptiveKeywords/gmd:MD_Keywords/gmd:keyword/gmx:Anchor[starts-with(@xlink:href, $SpatialDataServiceCategoryCodelistUri)]/@xlink:href"/>
-    </xsl:param>
+
     <xsl:param name="ServiceType">
       <xsl:value-of select="gmd:identificationInfo/*/srv:serviceType/gco:LocalName"/>
     </xsl:param>
@@ -1261,6 +1267,7 @@
       <xsl:apply-templates select="gmd:identificationInfo/*/gmd:descriptiveKeywords/gmd:MD_Keywords">
         <xsl:with-param name="MetadataLanguage" select="$MetadataLanguage"/>
         <xsl:with-param name="ResourceType" select="$ResourceType"/>
+        <xsl:with-param name="ServiceType" select="$ServiceType"/>
       </xsl:apply-templates>
 <!-- Identifier, 0..1 -->
 <!--
@@ -1314,9 +1321,6 @@
           <xsl:with-param name="MetadataLanguage" select="$MetadataLanguage"/>
         </xsl:apply-templates>
 -->
-        <xsl:if test="$ServiceCategory != ''">
-           <geodcatap:serviceCategory rdf:resource="{$ServiceCategory}"/>
-        </xsl:if>
         <geodcatap:serviceType rdf:resource="{$SpatialDataServiceTypeCodelistUri}/{$ServiceType}"/>
       </xsl:if>
 <!-- Spatial extent -->
@@ -1419,7 +1423,7 @@
           <xsl:variable name="Title">
             <xsl:for-each select="gmd:name">
               <dct:title xml:lang="{$MetadataLanguage}">
-                <xsl:value-of select="normalize-space(*)"/>
+                <xsl:value-of select="normalize-space(*[1])"/>
               </dct:title>
               <xsl:call-template name="LocalisedString">
                 <xsl:with-param name="term">dct:title</xsl:with-param>
@@ -1453,8 +1457,8 @@
 
           <xsl:variable name="TitleOrDescriptionOrPlaceholder">
             <xsl:choose>
-              <xsl:when test="normalize-space(gmd:name/*) != ''">
-                <xsl:value-of select="normalize-space(gmd:name/*)"/>
+              <xsl:when test="normalize-space(gmd:name/*[1]) != ''">
+                <xsl:value-of select="normalize-space(gmd:name/*[1])"/>
               </xsl:when>
               <xsl:when test="normalize-space(gmd:description/*) != ''">
                 <xsl:value-of select="normalize-space(gmd:description)"/>
@@ -3037,6 +3041,7 @@
   <xsl:template name="Keyword" match="gmd:identificationInfo/*/gmd:descriptiveKeywords/gmd:MD_Keywords">
     <xsl:param name="MetadataLanguage"/>
     <xsl:param name="ResourceType"/>
+    <xsl:param name="ServiceType"/>
     <xsl:param name="OriginatingControlledVocabularyURI" select="normalize-space(gmd:thesaurusName/gmd:CI_Citation/gmd:title/gmx:Anchor/@xlink:href)"/>
     <xsl:param name="OriginatingControlledVocabulary">
 <!--
@@ -3200,17 +3205,15 @@
                 <xsl:when test="gmx:Anchor/@xlink:href = 'http://data.europa.eu/eli/reg_impl/2023/138/oj'">
                   <dcatap:applicableLegislation rdf:resource="{gmx:Anchor/@xlink:href}"/>
                 </xsl:when>
-
+                
                 <!-- HVD Category -->
                 <xsl:when test="../gmd:thesaurusName/gmd:CI_Citation/gmd:title/gmx:Anchor/@xlink:href = 'http://data.europa.eu/bna/asd487ae75'">
                   <dcatap:hvdCategory rdf:resource="{gmx:Anchor/@xlink:href}"/>
                 </xsl:when>
 
                 <!-- Regular dcat:theme -->
-		<xsl:otherwise>
-                    <xsl:if test="not(starts-with(gmx:Anchor/@xlink:href, $SpatialDataServiceCategoryCodelistUri))">
-                      <dcat:theme rdf:resource="{gmx:Anchor/@xlink:href}"/>
-                    </xsl:if>
+                <xsl:otherwise>
+                  <dcat:theme rdf:resource="{gmx:Anchor/@xlink:href}"/>
                 </xsl:otherwise>
               </xsl:choose>
               
@@ -3220,9 +3223,7 @@
                 <xsl:if test="$profile = $extended">
 <!-- DEPRECATED: Mapping kept for backward compatibility with GeoDCAT-AP v1.* -->
                   <xsl:if test="$include-deprecated = 'yes'">
-	            <xsl:if test="not(starts-with(gmx:Anchor/@xlink:href, $SpatialDataServiceCategoryCodelistUri))">
-                      <dct:subject rdf:resource="{gmx:Anchor/@xlink:href}"/>
-		    </xsl:if>
+                    <dct:subject rdf:resource="{gmx:Anchor/@xlink:href}"/>
                   </xsl:if>
                 </xsl:if>
               </xsl:if>
@@ -4198,14 +4199,29 @@
 
   <xsl:template name="LocalisedString">
     <xsl:param name="term"/>
+    <xsl:variable name="primaryValue" select="normalize-space(*[self::gco:CharacterString|self::gmx:Anchor])"/>
     <xsl:for-each select="gmd:PT_FreeText/*/gmd:LocalisedCharacterString">
       <xsl:variable name="value" select="normalize-space(.)"/>
       <xsl:variable name="langs">
+        <!-- Extract raw value after '#' and lowercase it (handles both #EN and #locale-en) -->
+        <xsl:variable name="localeRaw" select="lower-case(substring-after(@locale, '#'))"/>
+        <!-- Strip the locale- prefix if present, so both #locale-en and #EN yield "en" -->
+        <xsl:variable name="localeCode">
+          <xsl:choose>
+            <xsl:when test="starts-with($localeRaw, lower-case($locale-prefix))">
+              <xsl:value-of select="substring-after($localeRaw, lower-case($locale-prefix))"/>
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:value-of select="$localeRaw"/>
+            </xsl:otherwise>
+          </xsl:choose>
+        </xsl:variable>
         <xsl:call-template name="Alpha3-to-Alpha2">
-          <xsl:with-param name="lang" select="substring-after(translate(translate(@locale, $uppercase, $lowercase), '#', ''), $locale-prefix)"/>
+          <xsl:with-param name="lang" select="$localeCode"/>
         </xsl:call-template>
       </xsl:variable>
-      <xsl:if test="$value != ''">
+      <!-- Skip locales whose value duplicates the primary gco:CharacterString/gmx:Anchor already output -->
+      <xsl:if test="$value != '' and not($primaryValue != '' and $value = $primaryValue)">
         <xsl:element name="{$term}">
           <xsl:attribute name="xml:lang"><xsl:value-of select="$langs"/></xsl:attribute>
           <xsl:value-of select="$value"/>

--- a/iso-19139-to-dcat-ap.xsl
+++ b/iso-19139-to-dcat-ap.xsl
@@ -87,7 +87,7 @@
     xmlns:xs     = "http://www.w3.org/2001/XMLSchema"
     xmlns:xsi    = "http://www.w3.org/2001/XMLSchema-instance"
     xmlns:xsl    = "http://www.w3.org/1999/XSL/Transform"
-    exclude-result-prefixes="earl gco gmd gml gmx i i-gp srv xlink xsi xsl wdrs"
+    exclude-result-prefixes="earl gco gmd gml gmx i i-gp srv xlink xs xsi xsl wdrs"
     version="2.0">
 
   <xsl:output method="xml"
@@ -213,13 +213,14 @@
   ("no") be included in the output.
 -->
 <!-- Uncomment to include deprecated mappings from the output -->
-
+<!--
   <xsl:param name="include-deprecated">yes</xsl:param>
+-->
 
 <!-- Uncomment to exclude deprecated mappings from the output -->
-<!--
+
   <xsl:param name="include-deprecated">no</xsl:param>
--->
+
 
 <!-- Parameter $CoupledResourceLookUp -->
 <!--
@@ -776,6 +777,9 @@
         </xsl:otherwise>
       </xsl:choose>
     </xsl:param>
+    <xsl:param name="ServiceCategory">
+      <xsl:value-of select="gmd:identificationInfo/*/gmd:descriptiveKeywords/gmd:MD_Keywords/gmd:keyword/gmx:Anchor[starts-with(@xlink:href, $SpatialDataServiceCategoryCodelistUri)]/@xlink:href"/>
+    </xsl:param>
 
     <xsl:param name="ServiceType">
       <xsl:value-of select="gmd:identificationInfo/*/srv:serviceType/gco:LocalName"/>
@@ -1267,7 +1271,7 @@
       <xsl:apply-templates select="gmd:identificationInfo/*/gmd:descriptiveKeywords/gmd:MD_Keywords">
         <xsl:with-param name="MetadataLanguage" select="$MetadataLanguage"/>
         <xsl:with-param name="ResourceType" select="$ResourceType"/>
-        <xsl:with-param name="ServiceType" select="$ServiceType"/>
+																  
       </xsl:apply-templates>
 <!-- Identifier, 0..1 -->
 <!--
@@ -1321,6 +1325,9 @@
           <xsl:with-param name="MetadataLanguage" select="$MetadataLanguage"/>
         </xsl:apply-templates>
 -->
+        <xsl:if test="$ServiceCategory != ''">
+           <geodcatap:serviceCategory rdf:resource="{$ServiceCategory}"/>
+        </xsl:if>
         <geodcatap:serviceType rdf:resource="{$SpatialDataServiceTypeCodelistUri}/{$ServiceType}"/>
       </xsl:if>
 <!-- Spatial extent -->
@@ -1718,7 +1725,8 @@
     </xsl:param>
 
     <xsl:param name="IndividualName">
-      <xsl:value-of select="normalize-space(gmd:individualName/*)"/>
+      <!--<xsl:value-of select="normalize-space(gmd:individualName/*)"/>-->
+	  <xsl:value-of select="normalize-space(gmd:individualName/*[self::gco:CharacterString|self::gmx:Anchor])"/>
     </xsl:param>
 
     <xsl:param name="IndividualName-FOAF">
@@ -3041,7 +3049,7 @@
   <xsl:template name="Keyword" match="gmd:identificationInfo/*/gmd:descriptiveKeywords/gmd:MD_Keywords">
     <xsl:param name="MetadataLanguage"/>
     <xsl:param name="ResourceType"/>
-    <xsl:param name="ServiceType"/>
+								   
     <xsl:param name="OriginatingControlledVocabularyURI" select="normalize-space(gmd:thesaurusName/gmd:CI_Citation/gmd:title/gmx:Anchor/@xlink:href)"/>
     <xsl:param name="OriginatingControlledVocabulary">
 <!--
@@ -3205,15 +3213,17 @@
                 <xsl:when test="gmx:Anchor/@xlink:href = 'http://data.europa.eu/eli/reg_impl/2023/138/oj'">
                   <dcatap:applicableLegislation rdf:resource="{gmx:Anchor/@xlink:href}"/>
                 </xsl:when>
-                
+
                 <!-- HVD Category -->
                 <xsl:when test="../gmd:thesaurusName/gmd:CI_Citation/gmd:title/gmx:Anchor/@xlink:href = 'http://data.europa.eu/bna/asd487ae75'">
                   <dcatap:hvdCategory rdf:resource="{gmx:Anchor/@xlink:href}"/>
                 </xsl:when>
 
                 <!-- Regular dcat:theme -->
-                <xsl:otherwise>
-                  <dcat:theme rdf:resource="{gmx:Anchor/@xlink:href}"/>
+		<xsl:otherwise>
+                    <xsl:if test="not(starts-with(gmx:Anchor/@xlink:href, $SpatialDataServiceCategoryCodelistUri))">
+                      <dcat:theme rdf:resource="{gmx:Anchor/@xlink:href}"/>
+                    </xsl:if>
                 </xsl:otherwise>
               </xsl:choose>
               
@@ -3223,7 +3233,9 @@
                 <xsl:if test="$profile = $extended">
 <!-- DEPRECATED: Mapping kept for backward compatibility with GeoDCAT-AP v1.* -->
                   <xsl:if test="$include-deprecated = 'yes'">
-                    <dct:subject rdf:resource="{gmx:Anchor/@xlink:href}"/>
+	            <xsl:if test="not(starts-with(gmx:Anchor/@xlink:href, $SpatialDataServiceCategoryCodelistUri))">
+                      <dct:subject rdf:resource="{gmx:Anchor/@xlink:href}"/>
+		    </xsl:if>
                   </xsl:if>
                 </xsl:if>
               </xsl:if>
@@ -4470,4 +4482,3 @@
   </xsl:template>
 
 </xsl:transform>
-


### PR DESCRIPTION
- Replace locale-preferred-lang parameter with locale-prefix/locale-default-lang
  to support multiple locale ID formats (#locale-en, #EN, #en)
- Update LocalisedString template to skip values duplicating the primary
  gco:CharacterString/gmx:Anchor already output
- Replace local:normalize-number() with format-number() for coordinate formatting
- Fix gmd:individualName to select only gco:CharacterString or gmx:Anchor,
  preventing multi-item sequence error with PT_FreeText_PropertyType inputs
- Set include-deprecated=no to remove deprecated GeoDCAT-AP v1 mappings
  (locn:geometry, vnd.geo+json bbox, schema:startDate, dct:type in
  prov:qualifiedAttribution)
- Add xs to exclude-result-prefixes to suppress xmlns:xs from output
- Transformation of input.xml produces output identical to expected_output.rdf